### PR TITLE
feat: Pocket dimension extension (correct fork)

### DIFF
--- a/data/json/furniture_and_terrain/terrain-dimensional.json
+++ b/data/json/furniture_and_terrain/terrain-dimensional.json
@@ -1,0 +1,37 @@
+[
+  {
+    "type": "terrain",
+    "id": "t_pd_border",
+    "name": "dimensional boundary",
+    "description": "An impenetrable barrier marking the edge of a pocket dimension.  The space beyond seems to shimmer and distort, as if reality itself is uncertain about what lies there.",
+    "symbol": "#",
+    "color": "magenta",
+    "move_cost": 0,
+    "coverage": 100,
+    "flags": [ "NOITEM", "NO_SIGHT", "NO_SCENT", "BLOCK_WIND", "FLAT", "INDOORS" ],
+    "connects_to": "WALL",
+    "bash": {
+      "str_min": -1,
+      "str_max": -1,
+      "sound": "The dimensional boundary absorbs the impact without effect.",
+      "sound_fail": "The dimensional boundary absorbs the impact without effect.",
+      "sound_vol": 2,
+      "sound_fail_vol": 2
+    },
+    "//": "str_min and str_max of -1 means this terrain cannot be bashed"
+  },
+  {
+    "type": "terrain",
+    "looks_like": "t_rock",
+    "id": "t_rock_border",
+    "name": "stone wall",
+    "description": "It's solid rock.",
+    "symbol": "#",
+    "color": "white",
+    "move_cost": 0,
+    "coverage": 100,
+    "flags": [ "NOITEM", "NO_SIGHT", "NO_SCENT", "BLOCK_WIND", "FLAT", "INDOORS" ],
+    "connects_to": "WALL",
+    "bash": { "str_min": -1, "str_max": -1, "sound": "whump!", "sound_fail": "whump!", "sound_vol": 2, "sound_fail_vol": 2 }
+  }
+]

--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -1043,5 +1043,10 @@
     "type": "item_action",
     "id": "dimension_travel",
     "name": { "str": "Travel to another dimension" }
+  },
+  {
+    "type": "item_action",
+    "id": "pocket_dimension",
+    "name": { "str": "Access a pocket dimension" }
   }
 ]

--- a/data/json/items/tool/dimensional_travel.json
+++ b/data/json/items/tool/dimensional_travel.json
@@ -1,0 +1,78 @@
+[
+  {
+    "id": "debug_testing_dimension_travel",
+    "type": "TOOL",
+    "copy-from": "pocketwatch",
+    "name": { "str": "dimensional pocket watch (desert)" },
+    "description": "A pocket watch that allows the user to travel to the desert dimension.  Used for debugging purposes only.  Transforms after use.",
+    "looks_like": "pocketwatch",
+    "weight": "500 g",
+    "volume": "500 ml",
+    "price": "1 kUSD",
+    "price_postapoc": "1 USD",
+    "material": [ "brass", "glass" ],
+    "use_action": [
+      {
+        "type": "dimension_travel",
+        "destination": "desert_test",
+        "travel_radius": 5,
+        "need_charges": 0,
+        "fail_message": "The watch vibrates but nothing happens.",
+        "success_message": "You feel a wrenching sensation as you are pulled through space and time."
+      },
+      {
+        "type": "transform",
+        "target": "debug_testing_dimension_travel_return",
+        "msg": "The watch reconfigures itself."
+      }
+    ]
+  },
+  {
+    "id": "debug_testing_dimension_travel_return",
+    "type": "TOOL",
+    "copy-from": "pocketwatch",
+    "name": { "str": "dimensional pocket watch (default)" },
+    "description": "A pocket watch that allows the user to return to the default dimension.  Used for debugging purposes only.",
+    "looks_like": "pocketwatch",
+    "weight": "500 g",
+    "volume": "500 ml",
+    "price": "1 kUSD",
+    "price_postapoc": "1 USD",
+    "material": [ "brass", "glass" ],
+    "use_action": [
+      {
+        "type": "dimension_travel",
+        "destination": "default",
+        "travel_radius": 5,
+        "need_charges": 0,
+        "fail_message": "The watch vibrates but nothing happens.",
+        "success_message": "You feel reality snap back into place."
+      },
+      { "type": "transform", "target": "debug_testing_dimension_travel", "msg": "The watch reconfigures itself." }
+    ]
+  },
+  {
+    "type": "TOOL",
+    "id": "pocket_dimension_key",
+    "name": { "str": "pocket cave key" },
+    "description": "A strange key that glows with an otherworldly light.  When activated, it opens a door to a pocket dimension containing a small extradimensional space.  The pocket dimension is tied to this key - if the key is destroyed, the dimension collapses.",
+    "weight": "50 g",
+    "volume": "10 ml",
+    "price": "1 kUSD",
+    "price_postapoc": "1 USD",
+    "symbol": "%",
+    "color": "light_gray",
+    "material": [ "steel" ],
+    "flags": [ "UNBREAKABLE" ],
+    "stackable": false,
+    "use_action": [
+      {
+        "type": "pocket_dimension",
+        "pocket_name": "Pocket Cave",
+        "entry_mapgen": "Cave",
+        "need_charges": 0,
+        "persistent": false
+      }
+    ]
+  }
+]

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -926,57 +926,5 @@
     "//": "used by the cloning vat and adds a var called 'place_monster_override'",
     "name": { "str": "artificial womb" },
     "description": "A single-use vessel for transporting clones safely from the cloning vat to the field.  Currently empty, if sufficiently sterile it can be used by a cloning vat to grow a creature from a viable DNA sample. "
-  },
-  {
-    "id": "debug_testing_dimension_travel",
-    "type": "TOOL",
-    "copy-from": "pocketwatch",
-    "name": { "str": "Dimensional Pocket Watch (Desert)" },
-    "description": "A pocket watch that allows the user to travel to the desert dimension.  Used for debugging purposes only.  Transforms after use.",
-    "looks_like": "pocketwatch",
-    "weight": "500 g",
-    "volume": "500 ml",
-    "price": "1 kUSD",
-    "price_postapoc": "1 USD",
-    "material": [ "brass", "glass" ],
-    "use_action": [
-      {
-        "type": "dimension_travel",
-        "destination": "desert_test",
-        "travel_radius": 5,
-        "need_charges": 0,
-        "fail_message": "The watch vibrates but nothing happens.",
-        "success_message": "You feel a wrenching sensation as you are pulled through space and time."
-      },
-      {
-        "type": "transform",
-        "target": "debug_testing_dimension_travel_return",
-        "msg": "The watch reconfigures itself."
-      }
-    ]
-  },
-  {
-    "id": "debug_testing_dimension_travel_return",
-    "type": "TOOL",
-    "copy-from": "pocketwatch",
-    "name": { "str": "Dimensional Pocket Watch (Default)" },
-    "description": "A pocket watch that allows the user to return to the default dimension.  Used for debugging purposes only.",
-    "looks_like": "pocketwatch",
-    "weight": "500 g",
-    "volume": "500 ml",
-    "price": "1 kUSD",
-    "price_postapoc": "1 USD",
-    "material": [ "brass", "glass" ],
-    "use_action": [
-      {
-        "type": "dimension_travel",
-        "destination": "default",
-        "travel_radius": 5,
-        "need_charges": 0,
-        "fail_message": "The watch vibrates but nothing happens.",
-        "success_message": "You feel reality snap back into place."
-      },
-      { "type": "transform", "target": "debug_testing_dimension_travel", "msg": "The watch reconfigures itself." }
-    ]
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
@@ -18,6 +18,15 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "pd_border",
+    "name": "nothing",
+    "sym": "#",
+    "color": "black",
+    "see_cost": 5,
+    "flags": [ "NO_ROTATE" ]
+  },
+  {
+    "type": "overmap_terrain",
     "id": "crater",
     "name": "crater",
     "sym": "O",

--- a/data/json/world_types.json
+++ b/data/json/world_types.json
@@ -1,0 +1,42 @@
+[
+  {
+    "type": "world_type",
+    "id": "default",
+    "name": { "str": "New England" },
+    "description": { "str": "The cataclysm really did a number on the property value." },
+    "region_settings": "default",
+    "generate_overmap": true,
+    "infinite_bounds": true,
+    "save_prefix": "",
+    "allow_npc_travel": true,
+    "allow_vehicle_travel": true
+  },
+  {
+    "type": "world_type",
+    "id": "pocket_dimension",
+    "name": { "str": "Pocket Dimension" },
+    "description": { "str": "A small bounded extradimensional space." },
+    "region_settings": "default",
+    "generate_overmap": false,
+    "infinite_bounds": false,
+    "boundary_terrain": "t_pd_border",
+    "simulate_when_inactive": false,
+    "save_prefix": "pocket_",
+    "allow_npc_travel": false,
+    "allow_vehicle_travel": false,
+    "parent_dimension": "default"
+  },
+  {
+    "type": "world_type",
+    "id": "desert_test",
+    "name": { "str": "Desert Dimension" },
+    "description": { "str": "An alternate dimension dominated by arid desert terrain." },
+    "region_settings": "desert_test",
+    "generate_overmap": true,
+    "infinite_bounds": true,
+    "save_prefix": "desert_test_",
+    "allow_npc_travel": false,
+    "allow_vehicle_travel": false,
+    "parent_dimension": "default"
+  }
+]

--- a/src/dimension_bounds.cpp
+++ b/src/dimension_bounds.cpp
@@ -1,0 +1,39 @@
+#include "dimension_bounds.h"
+
+#include "map.h"
+
+// Number of map squares per submap
+static constexpr int SEEX_SIZE = SEEX;
+static constexpr int SEEY_SIZE = SEEY;
+
+bool dimension_bounds::contains( const tripoint_abs_sm &p ) const
+{
+    return p.x() >= min_bound.x() && p.x() <= max_bound.x() &&
+           p.y() >= min_bound.y() && p.y() <= max_bound.y() &&
+           p.z() >= min_bound.z() && p.z() <= max_bound.z();
+}
+
+bool dimension_bounds::contains_ms( const tripoint_abs_ms &p ) const
+{
+    // Convert map square coordinates to submap coordinates
+    // Each submap is SEEX * SEEY map squares
+    tripoint_abs_sm sm_pos( p.x() / SEEX_SIZE, p.y() / SEEY_SIZE, p.z() );
+    return contains( sm_pos );
+}
+
+bool dimension_bounds::contains_omt( const tripoint_abs_omt &p ) const
+{
+    // Convert OMT to submap: each OMT spans 2 submaps in x and y
+    tripoint_abs_sm sm_pos( p.x() * 2, p.y() * 2, p.z() );
+    return contains( sm_pos );
+}
+
+bool dimension_bounds::contains_local( const tripoint &p, const tripoint_abs_sm &map_origin ) const
+{
+    // Convert local map position to absolute submap coordinates
+    // Local position is in map squares, origin is in submaps
+    int abs_x = map_origin.x() * SEEX_SIZE + p.x;
+    int abs_y = map_origin.y() * SEEY_SIZE + p.y;
+    tripoint_abs_ms abs_ms( abs_x, abs_y, p.z );
+    return contains_ms( abs_ms );
+}

--- a/src/dimension_bounds.h
+++ b/src/dimension_bounds.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "coordinates.h"
+#include "type_id.h"
+
+/**
+ * Defines the boundaries for a bounded dimension (pocket dimension).
+ *
+ * Boundaries are NOT stored in map data. They are:
+ * - Rendered as a specified terrain tile
+ * - Completely impassable
+ * - Zero storage cost
+ * - Skip ALL simulation (temperature, fields, construction, etc.)
+ * - Only interaction: bash shows a message
+ */
+struct dimension_bounds {
+    // Bounds in absolute submap coordinates
+    tripoint_abs_sm min_bound;
+    tripoint_abs_sm max_bound;
+
+    // What to display for out-of-bounds tiles
+    ter_str_id boundary_terrain;
+
+    // What to display for out-of-bounds overmap tiles
+    oter_str_id boundary_overmap_terrain;
+
+    /**
+     * Check if a point in absolute submap coordinates is within bounds.
+     */
+    bool contains( const tripoint_abs_sm &p ) const;
+
+    /**
+     * Check if a point in absolute overmap terrain coordinates is within bounds.
+     * Each OMT spans 2 submaps in x and y.
+     */
+    bool contains_omt( const tripoint_abs_omt &p ) const;
+
+    /**
+     * Check if a point in absolute map square coordinates is within bounds.
+     */
+    bool contains_ms( const tripoint_abs_ms &p ) const;
+
+    /**
+     * Check if a local map tripoint (relative to current map) is within bounds.
+     * Requires the map's absolute position for conversion.
+     * @param p local tripoint
+     * @param map_origin the map's absolute submap origin
+     */
+    bool contains_local( const tripoint &p, const tripoint_abs_sm &map_origin ) const;
+};

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -159,6 +159,7 @@
 #include "salvage.h"
 #include "scenario.h"
 #include "scent_map.h"
+#include "secondary_world.h"
 #include "scores_ui.h"
 #include "sdltiles.h"
 #include "sounds.h"
@@ -187,6 +188,7 @@
 #include "vpart_range.h"
 #include "wcwidth.h"
 #include "weather.h"
+#include "world_type.h"
 #include "worldfactory.h"
 #include "location_vector.h"
 class computer;
@@ -1360,6 +1362,12 @@ bool game::cleanup_at_end()
     sfx::fade_audio_group( sfx::group::context_themes, 300 );
     sfx::fade_audio_group( sfx::group::fatigue, 300 );
 
+    // Clear kept dimension worlds before clearing MAPBUFFER and item types.
+    // These hold submaps with items whose itype* pointers will become dangling
+    // once DynamicDataLoader::unload_data() calls item_controller->reset().
+    clear_kept_pocket();
+    clear_kept_origin();
+
     MAPBUFFER.clear();
     overmap_buffer.clear();
 
@@ -1516,6 +1524,8 @@ bool game::do_turn()
         gamemode->per_turn();
         calendar::turn += 1_turns;
     }
+    // Reset dimension swap flag now that the map is fully loaded and turn is processing
+    swapping_dimensions = false;
 
     // starting a new turn, clear out temperature cache
     weather_manager &weather = get_weather();
@@ -1674,6 +1684,13 @@ bool game::do_turn()
     if( calendar::once_every( 5_minutes ) ) {
         overmap_npc_move();
     }
+
+    // Simulate kept pocket dimension if loaded
+    if( kept_pocket_ && kept_pocket_->is_loaded() ) {
+        std::string sim_level = get_option<std::string>( "POCKET_SIMULATION_LEVEL" );
+        kept_pocket_->simulate_tick( sim_level );
+    }
+
     if( calendar::once_every( 10_seconds ) ) {
         ZoneScopedN( "field_emits" );
         for( const tripoint &elem : m.get_furn_field_locations() ) {
@@ -2708,8 +2725,9 @@ bool game::load_dimension_data()
 
     // Use dimension-specific filename
     std::string filename = "dimension_data";
-    if( !dimension_prefix.empty() ) {
-        filename += "_" + dimension_prefix;
+    const std::string dim_prefix = get_dimension_prefix();
+    if( !dim_prefix.empty() ) {
+        filename += "_" + dim_prefix;
     }
     filename += ".gsav";
 
@@ -2889,8 +2907,9 @@ bool game::save_dimension_data()
 {
     // Use dimension-specific filename
     std::string filename = "dimension_data";
-    if( !dimension_prefix.empty() ) {
-        filename += "_" + dimension_prefix;
+    const std::string dim_prefix = get_dimension_prefix();
+    if( !dim_prefix.empty() ) {
+        filename += "_" + dim_prefix;
     }
     filename += ".gsav";
 
@@ -11567,11 +11586,276 @@ void game::vertical_move( int movez, bool force, bool peeking )
     cata_event_dispatch::avatar_moves( u, m, u.pos() );
 }
 
-bool game::travel_to_dimension( const std::string &new_prefix,
-                                const std::string &region_type )
+world_type_id game::get_current_world_type() const
 {
+    if( current_world_type_.is_valid() ) {
+        return current_world_type_;
+    }
+    return world_types::get_default();
+}
+
+std::string game::get_dimension_prefix() const
+{
+    if( current_world_type_.is_valid() ) {
+        std::string prefix = current_world_type_.obj().save_prefix;
+        // For pocket dimensions, append instance ID to make unique save directories
+        if( !pocket_instance_id_.empty() ) {
+            prefix += pocket_instance_id_ + "_";
+        }
+        return prefix;
+    }
+    return "";
+}
+
+void game::set_current_world_type( const world_type_id &wt )
+{
+    current_world_type_ = wt;
+}
+
+std::string game::get_pocket_instance_id() const
+{
+    return pocket_instance_id_;
+}
+
+void game::set_pocket_instance_id( const std::string &id )
+{
+    pocket_instance_id_ = id;
+}
+
+tripoint_abs_sm game::get_pocket_origin_position() const
+{
+    return pocket_origin_position_;
+}
+
+void game::set_pocket_origin_position( const tripoint_abs_sm &pos )
+{
+    pocket_origin_position_ = pos;
+}
+
+std::string game::get_pocket_dimension_name() const
+{
+    return pocket_dimension_name_;
+}
+
+void game::set_pocket_dimension_name( const std::string &name )
+{
+    pocket_dimension_name_ = name;
+}
+
+secondary_world *game::get_kept_pocket() const
+{
+    return kept_pocket_.get();
+}
+
+bool game::has_kept_pocket( const std::string &instance_id ) const
+{
+    return kept_pocket_ && kept_pocket_->get_instance_id() == instance_id;
+}
+
+void game::clear_kept_pocket()
+{
+    if( kept_pocket_ ) {
+        kept_pocket_->unload();
+        kept_pocket_.reset();
+    }
+}
+
+bool game::has_kept_origin( const world_type_id &world_type,
+                            const std::string &instance_id ) const
+{
+    return kept_origin_ &&
+           kept_origin_->get_world_type() == world_type &&
+           kept_origin_->get_instance_id() == instance_id;
+}
+
+void game::clear_kept_origin()
+{
+    if( kept_origin_ ) {
+        kept_origin_->unload();
+        kept_origin_.reset();
+    }
+}
+
+bool game::travel_to_dimension( const world_type_id &new_world_type,
+                                const std::string &pocket_instance_id,
+                                const std::optional<dimension_bounds> &bounds,
+                                const std::optional<tripoint_abs_sm> &load_pos,
+                                const std::function<void()> &pre_load_callback )
+{
+    // Flush any items pending deferred deletion before switching dimensions.
+    // Without this, zombie item pointers in cata_arena can persist across the
+    // dimension transition and cause use-after-free crashes when the new
+    // dimension's submaps are actualized (e.g. in remove_rotten_items).
+    cleanup_arenas();
+
+    if( !new_world_type.is_valid() ) {
+        debugmsg( "travel_to_dimension: invalid world_type_id '%s'", new_world_type.str() );
+        return false;
+    }
+
+    const world_type &target_type = new_world_type.obj();
     map &here = get_map();
     avatar &player = get_avatar();
+
+    // Check if we can use a fast path via kept pocket or kept origin
+    bool fast_to_pocket = has_kept_pocket( pocket_instance_id );
+    bool fast_to_origin = has_kept_origin( new_world_type, pocket_instance_id );
+
+    if( fast_to_pocket || fast_to_origin ) {
+        if( fast_to_pocket ) {
+            add_msg( m_debug, "[DIM] Fast path: returning to kept pocket '%s'", pocket_instance_id );
+        } else {
+            add_msg( m_debug, "[DIM] Fast path: returning to kept origin '%s'",
+                     new_world_type.str() );
+        }
+
+        // Determine if this is a nested pocket-to-pocket transition
+        bool old_is_pocket = !pocket_instance_id_.empty();
+        bool new_is_pocket = !pocket_instance_id.empty();
+        bool nested = old_is_pocket && new_is_pocket;
+
+        // Unload NPCs and monsters from current dimension
+        unload_npcs();
+        for( monster &critter : all_monsters() ) {
+            despawn_monster( critter );
+        }
+        if( player.in_vehicle ) {
+            here.unboard_vehicle( player.pos() );
+        }
+
+        // Save current dimension's map memory
+        player.save_map_memory();
+
+        // Save current position before swapping
+        tripoint_abs_sm current_abs_sm( here.get_abs_sub() );
+
+        // Clear vehicle caches
+        for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+            here.clear_vehicle_list( z );
+        }
+        here.reset_vehicle_cache();
+
+        // Save and clear current buffers, wrapped in a transaction for performance
+        world *active_world = get_active_world();
+        if( active_world ) {
+            active_world->start_save_tx();
+        }
+        here.save();
+        overmap_buffer.save();
+        MAPBUFFER.save();
+        if( active_world ) {
+            active_world->commit_save_tx();
+        }
+
+        // Prevent temperature/weather code from accessing the grid while it's being
+        // cleared and rebuilt.  Must be set BEFORE clear_grid() to close the window.
+        swapping_dimensions = true;
+
+        // Capture current dimension into the opposite slot before clearing,
+        // unless this is a nested pocket-to-pocket transition
+        std::string sim_level = get_option<std::string>( "POCKET_SIMULATION_LEVEL" );
+        if( !nested && sim_level != "off" ) {
+            std::optional<dimension_bounds> current_bounds = here.get_dimension_bounds();
+            if( fast_to_pocket ) {
+                // Leaving origin to enter pocket: capture origin into kept_origin_
+                clear_kept_origin();
+                kept_origin_ = std::make_unique<secondary_world>( current_world_type_,
+                               pocket_instance_id_ );
+                here.clear_grid();
+                kept_origin_->capture_from_primary( current_bounds, current_abs_sm );
+                grid_tracker_ptr->clear();
+                add_msg( m_debug, "[DIM] Keeping origin loaded" );
+            } else {
+                // Leaving pocket to enter origin: capture pocket into kept_pocket_
+                clear_kept_pocket();
+                kept_pocket_ = std::make_unique<secondary_world>( current_world_type_,
+                               pocket_instance_id_ );
+                here.clear_grid();
+                kept_pocket_->capture_from_primary( current_bounds, current_abs_sm );
+                grid_tracker_ptr->clear();
+                add_msg( m_debug, "[DIM] Keeping pocket loaded" );
+            }
+        } else {
+            // Nested or disabled: clear everything normally
+            if( nested ) {
+                add_msg( m_debug, "[DIM] Nested pocket transition: clearing all kept worlds" );
+                clear_kept_pocket();
+                clear_kept_origin();
+            }
+            overmap_buffer.clear();
+            here.clear_grid();
+            MAPBUFFER.clear();
+            grid_tracker_ptr->clear();
+        }
+
+        // Restore from the appropriate kept world
+        if( fast_to_pocket ) {
+            kept_pocket_->restore_to_primary();
+            kept_pocket_.reset();
+        } else {
+            kept_origin_->restore_to_primary();
+            kept_origin_.reset();
+        }
+
+        // Update dimension state
+        current_world_type_ = new_world_type;
+        pocket_instance_id_ = pocket_instance_id;
+
+        // Track origin position for pocket dimensions
+        if( fast_to_pocket ) {
+            // Entering pocket from origin: save current overworld position
+            pocket_origin_position_ = current_abs_sm;
+        } else if( fast_to_origin ) {
+            // Exiting pocket to origin: clear saved position
+            pocket_origin_position_ = tripoint_abs_sm();
+        }
+
+        // Set region type
+        const std::string &region_type = target_type.region_settings_id;
+        if( !region_type.empty() ) {
+            overmap_buffer.current_region_type = region_type;
+        }
+
+        // Load dimension data and map
+        load_dimension_data();
+
+        // Clear stale bounds and set new ones before load_map
+        here.clear_dimension_bounds();
+        overmap_buffer.clear_dimension_bounds();
+        if( bounds ) {
+            here.set_dimension_bounds( *bounds );
+            overmap_buffer.set_dimension_bounds( *bounds );
+        }
+
+        // Invoke pre-load callback (e.g. place overmap specials) before loading submaps,
+        // so that submap generation uses the correct overmap terrain types.
+        if( pre_load_callback ) {
+            pre_load_callback();
+        }
+
+        load_map( load_pos.value_or( current_abs_sm ), false );
+
+        // Clear and load map memory for restored dimension
+        player.clear_map_memory();
+        player.load_map_memory();
+
+        // Reset caches
+        int const zmin = here.has_zlevels() ? -OVERMAP_DEPTH : here.get_abs_sub().z;
+        int const zmax = here.has_zlevels() ? OVERMAP_HEIGHT : here.get_abs_sub().z;
+        for( int z = zmin; z <= zmax; z++ ) {
+            here.access_cache( z ).map_memory_seen_cache.reset();
+            here.invalidate_map_cache( z );
+        }
+        here.build_map_cache( here.get_abs_sub().z );
+
+        load_npcs();
+        here.spawn_monsters( true );
+        get_weather().weather_override = weather_type_id::NULL_ID();
+        get_weather().set_nextweather( calendar::turn );
+        update_overmap_seen();
+
+        return true;
+    }
 
     // Unload all NPCs (they don't travel between dimensions)
     unload_npcs();
@@ -11583,15 +11867,27 @@ bool game::travel_to_dimension( const std::string &new_prefix,
         here.unboard_vehicle( player.pos() );
     }
 
-    // Save current dimension's data BEFORE changing dimension_prefix
+    // Save current dimension's data BEFORE changing current_world_type_
     // This includes overmap, MAPBUFFER, and dimension_data
-    // All saved with CURRENT dimension_prefix
+    // All saved with CURRENT save_prefix
+    // Wrap in a transaction so all DB writes are batched into a single commit,
+    // avoiding individual fsync per write which is extremely slow.
+    world *active_world = get_active_world();
     try {
+        if( active_world ) {
+            active_world->start_save_tx();
+        }
         here.save();
-        overmap_buffer.save();  // Save with current dimension_prefix
+        overmap_buffer.save();  // Save with current save_prefix
         MAPBUFFER.save();
         if( !save_dimension_data() ) {
+            if( active_world ) {
+                active_world->commit_save_tx();
+            }
             return false;
+        }
+        if( active_world ) {
+            active_world->commit_save_tx();
         }
     } catch( const std::exception &err ) {
         popup( _( "Failed to save map data: %s" ), err.what() );
@@ -11600,7 +11896,7 @@ bool game::travel_to_dimension( const std::string &new_prefix,
 
     add_msg( m_debug, "[DIM] Saved maps, overmaps, and dimension data" );
 
-    // Save current dimension's map memory BEFORE changing dimension_prefix
+    // Save current dimension's map memory BEFORE changing current_world_type_
     player.save_map_memory();
 
     add_msg( m_debug, "[DIM] Saved current dimension map memory" );
@@ -11612,57 +11908,136 @@ bool game::travel_to_dimension( const std::string &new_prefix,
 
     add_msg( m_debug, "[DIM] Reset vehicle cache" );
 
-    // Store old dimension prefix for reference
-    std::string old_prefix = dimension_prefix;
-
-    // CRITICAL: Change dimension_prefix BEFORE clearing buffers
-    // This way, when load_map() is called, it will load from the new dimension's files
-    // instead of trying to use the old dimension's cleared data
-    if( new_prefix != "default" ) {
-        dimension_prefix = new_prefix;
-    } else {
-        dimension_prefix.clear();
-    }
-
-    add_msg( m_debug, "[DIM] Changed dimension prefix from '%s' to '%s'",
-             old_prefix.empty() ? "default" : old_prefix.c_str(),
-             dimension_prefix.empty() ? "default" : dimension_prefix.c_str() );
+    // Store old world type for debug logging and keep-loaded check
+    world_type_id old_world_type = current_world_type_;
+    std::string old_pocket_instance = pocket_instance_id_;
 
     // Store current absolute submap position BEFORE clearing anything
     tripoint_abs_sm current_abs_sm( here.get_abs_sub() );
 
-    // Save current dimension's map to disk before clearing
-    here.save();
+    // Determine transition type for keep-loaded logic
+    bool old_is_pocket = !old_pocket_instance.empty();
+    bool new_is_pocket = !pocket_instance_id.empty();
+    bool nested = old_is_pocket && new_is_pocket;
 
-    // Clear all buffers in correct order
-    // dimension_prefix is already changed, so new loads will use new dimension
-    overmap_buffer.clear();
-    MAPBUFFER.clear();
-    grid_tracker_ptr->clear();
+    // Check if we should keep the old dimension loaded
+    std::string sim_level = get_option<std::string>( "POCKET_SIMULATION_LEVEL" );
+    bool should_keep_old = false;
+    enum class keep_target { none, as_pocket, as_origin };
+    keep_target keep_as = keep_target::none;
 
-    add_msg( m_debug, "[DIM] Cleared all buffers" );
+    if( sim_level != "off" && old_world_type.is_valid() && !nested ) {
+        if( !old_is_pocket && new_is_pocket ) {
+            // Entering pocket from non-pocket: keep origin
+            should_keep_old = true;
+            keep_as = keep_target::as_origin;
+        } else if( old_is_pocket && !new_is_pocket ) {
+            // Exiting pocket to non-pocket: keep pocket if bounded
+            const world_type &old_type = old_world_type.obj();
+            should_keep_old = !old_type.infinite_bounds;
+            keep_as = keep_target::as_pocket;
+        }
+    }
 
-    // hack to prevent crashes from temperature checks
-    // This returns to false in 'on_turn()' so it should be fine?
+    // Clear both kept worlds before capturing a new one (at-most-one invariant)
+    if( should_keep_old ) {
+        clear_kept_pocket();
+        clear_kept_origin();
+    } else if( nested ) {
+        // Nested pocket-to-pocket: disable all keeping
+        add_msg( m_debug, "[DIM] Nested pocket transition: clearing all kept worlds" );
+        clear_kept_pocket();
+        clear_kept_origin();
+    }
+
+    // CRITICAL: Change current_world_type_ and pocket_instance_id_ BEFORE clearing buffers
+    // This way, when load_map() is called, it will load from the new dimension's files
+    // instead of trying to use the old dimension's cleared data
+    current_world_type_ = new_world_type;
+    pocket_instance_id_ = pocket_instance_id;
+
+    // Track origin position for pocket dimensions
+    if( !old_is_pocket && new_is_pocket ) {
+        // Entering pocket from origin: save current overworld position
+        pocket_origin_position_ = current_abs_sm;
+    } else if( old_is_pocket && !new_is_pocket ) {
+        // Exiting pocket to origin: clear saved position
+        pocket_origin_position_ = tripoint_abs_sm();
+    }
+
+    add_msg( m_debug, "[DIM] Changed world type from '%s' to '%s' (pocket: '%s' -> '%s')",
+             old_world_type.is_valid() ? old_world_type.str() : "default",
+             current_world_type_.str(),
+             old_pocket_instance.c_str(),
+             pocket_instance_id_.c_str() );
+
+    // Prevent temperature/weather code from accessing the grid while it's being
+    // cleared and rebuilt.  Must be set BEFORE clear_grid() to close the window.
     swapping_dimensions = true;
+
+    // Either capture to secondary_world or clear buffers
+    if( should_keep_old ) {
+        // Get current dimension bounds if set
+        std::optional<dimension_bounds> current_bounds = here.get_dimension_bounds();
+
+        if( keep_as == keep_target::as_origin ) {
+            add_msg( m_debug, "[DIM] Keeping origin loaded" );
+            kept_origin_ = std::make_unique<secondary_world>( old_world_type, old_pocket_instance );
+            here.clear_grid();
+            kept_origin_->capture_from_primary( current_bounds, current_abs_sm );
+        } else {
+            add_msg( m_debug, "[DIM] Keeping old pocket '%s' loaded", old_pocket_instance );
+            kept_pocket_ = std::make_unique<secondary_world>( old_world_type, old_pocket_instance );
+            here.clear_grid();
+            kept_pocket_->capture_from_primary( current_bounds, current_abs_sm );
+        }
+
+        // Grid tracker still needs to be cleared
+        grid_tracker_ptr->clear();
+    } else {
+        // Normal clear behavior
+        overmap_buffer.clear();
+        here.clear_grid();
+        MAPBUFFER.clear();
+        grid_tracker_ptr->clear();
+    }
+
+    add_msg( m_debug, "[DIM] Cleared/captured buffers (kept=%s)", should_keep_old ? "yes" : "no" );
 
     // Set region_type BEFORE loading dimension data
     // This ensures new dimensions use the correct region settings
+    const std::string &region_type = target_type.region_settings_id;
     if( !region_type.empty() ) {
-        overmap_buffer.current_region_type = ( region_type == "default" ) ? "default" : region_type;
+        overmap_buffer.current_region_type = region_type;
     } else {
-        debugmsg( "travel_to_dimension: region_type is empty!" );
+        debugmsg( "travel_to_dimension: world_type '%s' has empty region_settings_id!",
+                  new_world_type.str() );
     }
 
     // Load in data specific to the dimension (like weather)
     // This will override current_region_type if dimension data file exists
     load_dimension_data();
 
-    // Load the new dimension's map
-    // dimension_prefix was already changed, so this loads from new dimension files
-    // MAPBUFFER was cleared, so loadn() will generate/load new submaps
-    // This is safe: loadn() only writes to grid via setsubmap(), never reads from it
-    load_map( current_abs_sm, false );
+    // Clear any stale dimension bounds, then set new ones if entering a bounded dimension.
+    // This must happen before load_map so loadn() knows which submaps are out-of-bounds.
+    here.clear_dimension_bounds();
+    overmap_buffer.clear_dimension_bounds();
+    if( bounds ) {
+        here.set_dimension_bounds( *bounds );
+        overmap_buffer.set_dimension_bounds( *bounds );
+    }
+
+    // Invoke pre-load callback (e.g. place overmap specials) before loading submaps,
+    // so that submap generation uses the correct overmap terrain types.
+    if( pre_load_callback ) {
+        pre_load_callback();
+    }
+
+    // Load the new dimension's map at the destination position if provided,
+    // otherwise fall back to the current position. Loading at the destination
+    // avoids a costly incremental map shift in update_map() when the destination
+    // is far from the current position (e.g. entering/exiting pocket dimensions).
+    load_map( load_pos.value_or( current_abs_sm ), false );
 
     add_msg( m_debug, "[DIM] Loaded new dimension map" );
 

--- a/src/game.h
+++ b/src/game.h
@@ -20,6 +20,7 @@
 #include "character_id.h"
 #include "coordinates.h"
 #include "creature.h"
+#include "dimension_bounds.h"
 #include "cursesdef.h"
 #include "enums.h"
 #include "game_constants.h"
@@ -34,6 +35,7 @@ class Character;
 class Creature_tracker;
 class item;
 class monster;
+class secondary_world;
 class spell_events;
 class drop_token_provider;
 
@@ -241,17 +243,83 @@ class game
         void start_hauling( const tripoint &pos );
         /**
         * Moves the player to an alternate dimension.
-        * @param prefix identifies the dimension and its properties.
-        * @param region_type the region type for the dimension.
+        * @param new_world_type identifies the dimension and its properties.
+        * @param pocket_instance_id optional instance ID for pocket dimensions (empty for non-pockets)
+        * @param bounds optional dimension bounds to set before loading the map
+        * @param load_pos optional submap position to center the map load on.
+        *        If not provided, the map loads at the player's current position.
+        * @param pre_load_callback optional callback invoked after dimension setup
+        *        but before load_map(). Use this to place overmap specials so that
+        *        submap generation uses the correct overmap terrain types.
         */
-        bool travel_to_dimension( const std::string &prefix, const std::string &region_type );
+        bool travel_to_dimension( const world_type_id &new_world_type,
+                                  const std::string &pocket_instance_id = "",
+                                  const std::optional<dimension_bounds> &bounds = std::nullopt,
+                                  const std::optional<tripoint_abs_sm> &load_pos = std::nullopt,
+                                  const std::function<void()> &pre_load_callback = nullptr );
         /**
          * Retrieve the identifier of the current dimension.
-         * TODO: this should be a dereferencable id that gives properties of the dimension.
          */
-        std::string get_dimension_prefix() {
-            return dimension_prefix;
-        }
+        world_type_id get_current_world_type() const;
+        /**
+         * Set the current world type (for save/load only).
+         * For gameplay, use travel_to_dimension() instead.
+         */
+        void set_current_world_type( const world_type_id &wt );
+        /**
+         * Get the pocket instance ID for the current dimension.
+         * Returns empty string if not in a pocket dimension.
+         */
+        std::string get_pocket_instance_id() const;
+        /**
+         * Set the pocket instance ID (for save/load only).
+         */
+        void set_pocket_instance_id( const std::string &id );
+        /**
+         * Get the player's overworld position from before entering a pocket dimension.
+         * Only meaningful when inside a pocket dimension.
+         */
+        tripoint_abs_sm get_pocket_origin_position() const;
+        /**
+         * Set the player's overworld position (for save/load and dimension travel).
+         */
+        void set_pocket_origin_position( const tripoint_abs_sm &pos );
+        /**
+         * Get the display name of the current pocket dimension.
+         * Returns empty string if not in a pocket or no name was set.
+         */
+        std::string get_pocket_dimension_name() const;
+        /**
+         * Set the display name of the current pocket dimension.
+         */
+        void set_pocket_dimension_name( const std::string &name );
+        /**
+         * Get the kept (secondary) pocket dimension, if any.
+         * Returns nullptr if no pocket is kept loaded.
+         */
+        secondary_world *get_kept_pocket() const;
+        /**
+         * Check if we have a kept pocket matching the given instance ID.
+         */
+        bool has_kept_pocket( const std::string &instance_id ) const;
+        /**
+         * Clear and destroy the kept pocket dimension.
+         */
+        void clear_kept_pocket();
+        /**
+         * Check if we have a kept origin matching the given world type and instance ID.
+         */
+        bool has_kept_origin( const world_type_id &world_type,
+                              const std::string &instance_id ) const;
+        /**
+         * Clear and destroy the kept origin dimension.
+         */
+        void clear_kept_origin();
+        /**
+         * Retrieve the save prefix for the current dimension.
+         * Used for file naming (maps, overmaps, etc.)
+         */
+        std::string get_dimension_prefix() const;
         /** Returns the other end of the stairs (if any). May query, affect u etc.  */
         std::optional<tripoint> find_stairs( map &mp, int z_after, bool peeking );
         std::optional<tripoint> find_or_make_stairs( map &mp, int z_after, bool &rope_ladder,
@@ -1100,10 +1168,16 @@ class game
         */
         bool slip_down();
 
-        //currently used as a hacky workaround for dimension swapping
+        // Set during dimension transitions to prevent temperature/weather code from
+        // accessing partially-loaded map data. Reset to false at the start of the next turn.
         bool swapping_dimensions = false;
     private:
-        std::string dimension_prefix;
+        world_type_id current_world_type_;
+        std::string pocket_instance_id_;  // Instance ID for pocket dimensions (empty if not in pocket)
+        tripoint_abs_sm pocket_origin_position_;  // Player's overworld position before entering a pocket
+        std::string pocket_dimension_name_;  // Display name of the current pocket dimension
+        std::unique_ptr<secondary_world> kept_pocket_;  // Last visited pocket dimension (if kept loaded)
+        std::unique_ptr<secondary_world> kept_origin_;  // Origin dimension when inside a pocket (if kept loaded)
     private:
         location_vector<item> fake_items;
     public:

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -106,6 +106,7 @@
 #include "vitamin.h"
 #include "weather.h"
 #include "weather_type.h"
+#include "world_type.h"
 #include "worldfactory.h"
 
 #if defined(TILES)
@@ -257,6 +258,7 @@ void DynamicDataLoader::initialize()
     add( "fault", &fault::load_fault );
     add( "field_type", &field_types::load );
     add( "weather_type", &weather_types::load );
+    add( "world_type", &world_types::load );
     add( "ammo_effect", &ammo_effects::load );
     add( "emit", &emit::load_emit );
     add( "activity_type", &activity_type::load );
@@ -633,6 +635,7 @@ void DynamicDataLoader::unload_data()
     vpart_info::reset();
     weapon_category::reset();
     weather_types::reset();
+    world_types::reset();
     zone_type::reset_zones();
     l10n_data::unload_mod_catalogues();
 #if defined(TILES)
@@ -663,6 +666,7 @@ void DynamicDataLoader::finalize_loaded_data( loading_ui &ui )
             { _( "Body parts" ), &body_part_type::finalize_all },
             { _( "Bionics" ), &bionic_data::finalize_all },
             { _( "Weather types" ), &weather_types::finalize_all },
+            { _( "World types" ), &world_types::finalize_all },
             { _( "Field types" ), &field_types::finalize_all },
             { _( "Ammo effects" ), &ammo_effects::finalize_all },
             { _( "Emissions" ), &emit::finalize },
@@ -746,6 +750,7 @@ void DynamicDataLoader::check_consistency( loading_ui &ui )
             },
             { _( "Vitamins" ), &vitamin::check_consistency },
             { _( "Weather types" ), &weather_types::check_consistency },
+            { _( "World types" ), &world_types::check_consistency },
             { _( "Field types" ), &field_types::check_consistency },
             { _( "Ammo effects" ), &ammo_effects::check_consistency },
             { _( "Emissions" ), &emit::check_consistency },

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7643,6 +7643,32 @@ bool item::is_craft() const
     return craft_data_ != nullptr;
 }
 
+bool item::is_pocket_dimension_key() const
+{
+    return pocket_dim.has_value();
+}
+
+item::pocket_dimension_data *item::get_pocket_dimension_data()
+{
+    if( pocket_dim.has_value() ) {
+        return &pocket_dim.value();
+    }
+    return nullptr;
+}
+
+const item::pocket_dimension_data *item::get_pocket_dimension_data() const
+{
+    if( pocket_dim.has_value() ) {
+        return &pocket_dim.value();
+    }
+    return nullptr;
+}
+
+void item::set_pocket_dimension_data( pocket_dimension_data &&data )
+{
+    pocket_dim = std::move( data );
+}
+
 bool item::is_funnel_container( units::volume &bigger_than ) const
 {
     if( !is_bucket() && !is_watertight_container() ) {
@@ -9661,6 +9687,15 @@ detached_ptr<item> item::actualize_rot( detached_ptr<item> &&self, const tripoin
                                         temperature_flag temperature,
                                         const weather_manager &weather )
 {
+    // Guard against null or invalid items that can survive save/load cycles
+    // during dimension transitions (e.g. zombie items from deferred arena cleanup).
+    if( !self || !self->type || self->type == nullitem() ) {
+        if( self ) {
+            debugmsg( "actualize_rot: skipping item with %s type at %s",
+                      self->type ? "null-type" : "null", pnt.to_string() );
+        }
+        return std::move( self );
+    }
     if( self->goes_bad() ) {
         return process_rot( std::move( self ), false, pnt, nullptr, temperature, weather );
     } else if( self->type->container && self->type->container->preserves ) {
@@ -9669,6 +9704,9 @@ detached_ptr<item> item::actualize_rot( detached_ptr<item> &&self, const tripoin
     } else if( self->type->container && self->type->container->seals ) {
         // Items inside rot but do not vanish as the container seals them in.
         self->contents.remove_top_items_with( [&pnt, &temperature, &weather]( detached_ptr<item> &&it ) {
+            if( !it || !it->type || it->type == nullitem() ) {
+                return std::move( it );
+            }
             if( it->goes_bad() ) {
                 it = process_rot( std::move( it ), true, pnt, nullptr, temperature, weather );
             }

--- a/src/item.h
+++ b/src/item.h
@@ -1282,6 +1282,7 @@ class item : public location_visitable<item>, public game_object<item>
         bool is_transformable() const;
         bool is_artifact() const;
         bool is_relic() const;
+        bool is_pocket_dimension_key() const;
         bool is_bucket() const;
         bool is_bucket_nonempty() const;
 
@@ -2274,6 +2275,45 @@ class item : public location_visitable<item>, public game_object<item>
         bool has_tools_to_continue() const;
         void set_cached_tool_selections( const std::vector<comp_selection<tool_comp>> &selections );
         const std::vector<comp_selection<tool_comp>> &get_cached_tool_selections() const;
+
+        /**
+         * Data for items that act as keys to pocket dimensions.
+         */
+        struct pocket_dimension_data {
+            std::string instance_id;              // Unique identifier (UUID-like)
+            world_type_id dimension_type;         // Which world_type to use
+            tripoint_abs_omt entry_point;         // Where player spawns on entry
+            tripoint_abs_omt bounds_min;          // Minimum bounds (OMT coords)
+            tripoint_abs_omt bounds_max;          // Maximum bounds (OMT coords)
+            bool is_initialized = false;          // Has the pocket data been set up?
+            bool terrain_generated = false;       // Has the terrain been generated?
+
+            // Return tracking - where to go when exiting this pocket
+            world_type_id return_dimension;       // Which dimension to return to
+            std::string return_instance_id;       // If returning to another pocket (empty for base)
+            tripoint_abs_omt return_point;        // Where to place player on exit
+
+            void serialize(JsonOut& jsout) const;
+            void deserialize(JsonIn& jsin);
+
+            bool operator==( const pocket_dimension_data &rhs ) const;
+        };
+
+        std::optional<pocket_dimension_data> pocket_dim;
+
+
+        /**
+         * Get the pocket dimension data for this item.
+         * Returns nullptr if this item is not a pocket dimension key.
+         */
+        pocket_dimension_data *get_pocket_dimension_data();
+        const pocket_dimension_data *get_pocket_dimension_data() const;
+
+        /**
+         * Initialize pocket dimension data for this item.
+         * Should only be called once when the pocket is first used.
+         */
+        void set_pocket_dimension_data( pocket_dimension_data &&data );
 
         const std::vector<enchantment> &get_enchantments() const;
 

--- a/src/item.h
+++ b/src/item.h
@@ -2280,6 +2280,7 @@ class item : public location_visitable<item>, public game_object<item>
          * Data for items that act as keys to pocket dimensions.
          */
         struct pocket_dimension_data {
+            pocket_dimension_data() {}
             std::string instance_id;              // Unique identifier (UUID-like)
             world_type_id dimension_type;         // Which world_type to use
             tripoint_abs_omt entry_point;         // Where player spawns on entry

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1123,6 +1123,7 @@ void Item_factory::init()
     add_actor( std::make_unique<iuse_flowerpot_plant>() );
     add_actor( std::make_unique<iuse_flowerpot_collect>() );
     add_actor( std::make_unique<iuse_dimension_travel>() );
+    add_actor( std::make_unique<iuse_pocket_dimension>() );
 
     // An empty dummy group, it will not spawn anything. However, it makes that item group
     // id valid, so it can be used all over the place without need to explicitly check for it.

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -36,6 +36,7 @@
 #include "crafting.h"
 #include "creature.h"
 #include "debug.h"
+#include "dimension_bounds.h"
 #include "effect.h"
 #include "enum_conversions.h"
 #include "enums.h"
@@ -74,6 +75,7 @@
 #include "options.h"
 #include "output.h"
 #include "overmap.h"
+#include "overmap_special.h"
 #include "overmap_ui.h"
 #include "overmapbuffer.h"
 #include "player.h"
@@ -106,6 +108,7 @@
 #include "vpart_position.h"
 #include "vpart_range.h"
 #include "weather.h"
+#include "world_type.h"
 
 static const activity_id ACT_FIRSTAID( "ACT_FIRSTAID" );
 static const activity_id ACT_MAKE_ZLAVE( "ACT_MAKE_ZLAVE" );
@@ -6909,7 +6912,9 @@ std::unique_ptr<iuse_actor> iuse_dimension_travel::clone() const
 
 void iuse_dimension_travel::load( const JsonObject &obj )
 {
-    obj.read( "destination", destination );
+    if( obj.has_string( "destination" ) ) {
+        destination = world_type_id( obj.get_string( "destination" ) );
+    }
     obj.read( "travel_radius", travel_radius );
     obj.read( "need_charges", need_charges );
     obj.read( "fail_message", fail_message );
@@ -6936,24 +6941,23 @@ ret_val<bool> iuse_dimension_travel::can_use( const Character &, const item &it,
 
 void iuse_dimension_travel::dimension_travel( player &p, item &, const tripoint &pos ) const
 {
-    if( destination.empty() ) {
+    if( destination.is_empty() ) {
         p.add_msg_if_player( m_bad, _( "This item has no destination configured." ) );
+        return;
+    }
+    if( !destination.is_valid() ) {
+        debugmsg( "iuse_dimension_travel: destination '%s' is not a valid world_type",
+                  destination.str() );
         return;
     }
 
     // Debug: Show current and target dimensions
     add_msg( m_debug, "[DIM_TRAVEL] Current region_type: %s", overmap_buffer.current_region_type );
-    add_msg( m_debug, "[DIM_TRAVEL] Current dimension_prefix: %s", g->get_dimension_prefix() );
-    add_msg( m_debug, "[DIM_TRAVEL] Target destination: %s", destination );
+    add_msg( m_debug, "[DIM_TRAVEL] Current world_type: %s", g->get_current_world_type().str() );
+    add_msg( m_debug, "[DIM_TRAVEL] Target destination: %s", destination.str() );
 
     // Check if already in target dimension
-    // Both dimension_prefix and region_type should match the destination
-    std::string current_dim = g->get_dimension_prefix();
-    if( current_dim.empty() ) {
-        current_dim = "default";
-    }
-
-    if( current_dim == destination ) {
+    if( g->get_current_world_type() == destination ) {
         p.add_msg_if_player( m_info, _( "You are already in that dimension." ) );
         add_msg( m_debug, "[DIM_TRAVEL] Already in target dimension" );
         return;
@@ -6978,9 +6982,279 @@ void iuse_dimension_travel::dimension_travel( player &p, item &, const tripoint 
         p.add_msg_if_player( m_good, "%s", _( success_message ) );
     }
 
-    // Use destination as both the dimension prefix and region type
-    // The dimension prefix determines which save folder to use
-    // The region type determines the world generation parameters
+    // Travel to the destination world type
     // NPCs and vehicles do not travel between dimensions
-    g->travel_to_dimension( destination, destination );
+    // When traveling from a pocket dimension, use the saved origin position
+    // so the destination loads at the player's original overworld coordinates
+    std::optional<tripoint_abs_sm> load_pos;
+    if( !g->get_pocket_instance_id().empty() ) {
+        load_pos = g->get_pocket_origin_position();
+    }
+    g->travel_to_dimension( destination, "", std::nullopt, load_pos );
+}
+
+// -------------------
+// iuse_pocket_dimension
+// -------------------
+
+std::unique_ptr<iuse_actor> iuse_pocket_dimension::clone() const
+{
+    return std::make_unique<iuse_pocket_dimension>( *this );
+}
+
+void iuse_pocket_dimension::load( const JsonObject &obj )
+{
+    if( obj.has_string( "pocket_type" ) ) {
+        pocket_type = world_type_id( obj.get_string( "pocket_type" ) );
+    }
+    obj.read( "entry_mapgen", entry_mapgen );
+    obj.read( "persistent", persistent );
+    obj.read( "need_charges", need_charges );
+    obj.read( "pocket_name", pocket_name );
+    if( obj.has_string( "boundary_terrain" ) ) {
+        boundary_terrain = ter_str_id( obj.get_string( "boundary_terrain" ) );
+    }
+}
+
+int iuse_pocket_dimension::use( player &p, item &it, bool, const tripoint & ) const
+{
+    item::pocket_dimension_data *pd = it.get_pocket_dimension_data();
+
+    // If pocket is not initialized, initialize it on first use
+    if( !pd || !pd->is_initialized ) {
+        initialize_pocket( it );
+        pd = it.get_pocket_dimension_data();
+        if( !pd ) {
+            p.add_msg_if_player( m_bad, _( "Failed to initialize the pocket dimension." ) );
+            return 0;
+        }
+    }
+
+    // Determine if we're inside this pocket or outside
+    const world_type_id current_dim = g->get_current_world_type();
+    const std::string current_instance = g->get_pocket_instance_id();
+
+    // Check if we're inside THIS pocket dimension
+    if( current_dim == pd->dimension_type && current_instance == pd->instance_id ) {
+        // We're inside - exit to return point
+        exit_pocket( p, it );
+    } else if( current_dim == pd->return_dimension &&
+               current_instance == pd->return_instance_id ) {
+        // We're at the dimension this pocket exits to - we can enter
+        enter_pocket( p, it );
+    } else {
+        // We're in some other dimension - can't use this pocket key here
+        p.add_msg_if_player( m_info,
+                             _( "You can only use this from where you last exited this pocket." ) );
+        return 0;
+    }
+
+    return need_charges;
+}
+
+ret_val<bool> iuse_pocket_dimension::can_use( const Character &, const item &it, bool,
+        const tripoint & ) const
+{
+    if( it.ammo_remaining() < need_charges ) {
+        return ret_val<bool>::make_failure( _( "The %s doesn't have enough charges." ), it.tname() );
+    }
+    return ret_val<bool>::make_success();
+}
+
+void iuse_pocket_dimension::initialize_pocket( item &it ) const
+{
+    if( !pocket_type.is_valid() ) {
+        debugmsg( "iuse_pocket_dimension: invalid pocket_type %s", pocket_type.str() );
+        return;
+    }
+
+    item::pocket_dimension_data pd;
+
+    // Generate unique instance ID (timestamp + random)
+    pd.instance_id = string_format( "%d_%d", to_turn<int>( calendar::turn ), rng( 0, 99999 ) );
+    pd.dimension_type = pocket_type;
+    pd.is_initialized = true;
+
+    // Set initial return dimension to current dimension (base reality typically)
+    pd.return_dimension = g->get_current_world_type();
+    pd.return_instance_id = g->get_pocket_instance_id();
+
+    // The return point will be set when entering
+
+    // Calculate bounds from entry_mapgen (overmap_special)
+    overmap_special_id special_id( entry_mapgen );
+    if( special_id.is_valid() ) {
+        const overmap_special &special = special_id.obj();
+        std::vector<overmap_special_locations> locations = special.required_locations();
+
+        if( !locations.empty() ) {
+            // Find min and max coordinates across all locations
+            tripoint min_pos = locations[0].p;
+            tripoint max_pos = locations[0].p;
+
+            for( const overmap_special_locations &loc : locations ) {
+                min_pos.x = std::min( min_pos.x, loc.p.x );
+                min_pos.y = std::min( min_pos.y, loc.p.y );
+                min_pos.z = std::min( min_pos.z, loc.p.z );
+                max_pos.x = std::max( max_pos.x, loc.p.x );
+                max_pos.y = std::max( max_pos.y, loc.p.y );
+                max_pos.z = std::max( max_pos.z, loc.p.z );
+            }
+
+            // Set bounds based on the special's extent
+            // The special's coordinates are relative, so we use them directly
+            pd.bounds_min = tripoint_abs_omt( min_pos );
+            pd.bounds_max = tripoint_abs_omt( max_pos );
+
+            // Set entry point to the center of the special
+            pd.entry_point = tripoint_abs_omt(
+                                 ( min_pos.x + max_pos.x ) / 2,
+                                 ( min_pos.y + max_pos.y ) / 2,
+                                 ( min_pos.z + max_pos.z ) / 2
+                             );
+        } else {
+            // Fallback if no locations defined
+            debugmsg( "iuse_pocket_dimension: overmap_special '%s' has no locations", entry_mapgen );
+            pd.entry_point = tripoint_abs_omt( 0, 0, 0 );
+            pd.bounds_min = tripoint_abs_omt( 0, 0, 0 );
+            pd.bounds_max = tripoint_abs_omt( 0, 0, 0 );
+        }
+    } else {
+        // Fallback if entry_mapgen is not a valid overmap_special
+        debugmsg( "iuse_pocket_dimension: invalid entry_mapgen '%s'", entry_mapgen );
+        pd.entry_point = tripoint_abs_omt( 0, 0, 0 );
+        pd.bounds_min = tripoint_abs_omt( 0, 0, 0 );
+        pd.bounds_max = tripoint_abs_omt( 0, 0, 0 );
+    }
+
+    it.set_pocket_dimension_data( std::move( pd ) );
+}
+
+// Helper function to find a safe, passable position near the target
+static tripoint find_safe_spawn( const tripoint &target )
+{
+    map &here = get_map();
+
+    // First check if the target itself is passable
+    if( here.passable( target ) && !g->critter_at( target ) ) {
+        return target;
+    }
+
+    // Search in expanding radius for a passable spot
+    for( int radius = 1; radius <= 10; radius++ ) {
+        for( const tripoint &p : here.points_in_radius( target, radius ) ) {
+            if( here.passable( p ) && !g->critter_at( p ) ) {
+                return p;
+            }
+        }
+    }
+
+    // If no safe spot found, return target anyway (will be handled by game)
+    return target;
+}
+
+void iuse_pocket_dimension::enter_pocket( player &p, item &it ) const
+{
+    item::pocket_dimension_data *pd = it.get_pocket_dimension_data();
+    if( !pd ) {
+        return;
+    }
+
+    // Store return information
+    pd->return_dimension = g->get_current_world_type();
+    pd->return_instance_id = g->get_pocket_instance_id();
+    pd->return_point = p.global_omt_location();
+
+    // Set dimension bounds on map
+    dimension_bounds bounds;
+    bounds.min_bound = tripoint_abs_sm(
+                           pd->bounds_min.x() * 2, pd->bounds_min.y() * 2, pd->bounds_min.z() );
+    bounds.max_bound = tripoint_abs_sm(
+                           pd->bounds_max.x() * 2 + 1, pd->bounds_max.y() * 2 + 1, pd->bounds_max.z() );
+    // Priority: actor-level override > world_type > hardcoded default
+    if( boundary_terrain && boundary_terrain->is_valid() ) {
+        bounds.boundary_terrain = *boundary_terrain;
+    } else {
+        bounds.boundary_terrain = pocket_type.obj().boundary_terrain.value_or(
+                                      ter_str_id( "t_pd_border" ) );
+    }
+    bounds.boundary_overmap_terrain = oter_str_id( "pd_border" );
+
+    p.add_msg_if_player( m_good, _( "You enter the pocket dimension." ) );
+
+    // Compute destination submap position from entry point so the map loads centered
+    // on the destination, avoiding a costly incremental shift in update_map()
+    tripoint_abs_sm dest_sm = project_to<coords::sm>( pd->entry_point );
+
+    // Build a pre-load callback to place the overmap special BEFORE submaps are generated.
+    // This ensures submap generation uses the correct overmap terrain types (e.g. "Cave")
+    // instead of the default oter_id(0) which generates field/grass.
+    std::function<void()> pre_load;
+    if( !pd->terrain_generated && !entry_mapgen.empty() ) {
+        pre_load = [&]() {
+            overmap_special_id special_id( entry_mapgen );
+            if( special_id.is_valid() ) {
+                overmap &om = *overmap_buffer.get_om_global( pd->entry_point ).om;
+                tripoint_om_omt local_pos = overmap_buffer.get_om_global( pd->entry_point ).local;
+                om.place_special_forced( special_id, local_pos, om_direction::type::north );
+                pd->terrain_generated = true;
+            }
+        };
+    }
+
+    // Set the pocket dimension display name for the overmap sidebar
+    g->set_pocket_dimension_name( pocket_name );
+
+    // Travel to the pocket dimension, passing bounds, destination position,
+    // and the pre-load callback to place the overmap special before map generation
+    g->travel_to_dimension( pd->dimension_type, pd->instance_id, bounds, dest_sm, pre_load );
+
+    // Teleport player to entry point
+    // Convert entry_point (OMT coords) to absolute map squares, then to local
+    tripoint_abs_ms entry_abs_ms = project_to<coords::ms>( pd->entry_point );
+    // Add offset to center of the OMT (OMT is 24x24 map squares)
+    entry_abs_ms += tripoint( SEEX, SEEY, 0 );
+    // The map is already loaded centered on the destination (via load_pos parameter),
+    // so local coordinates are valid without needing a map shift first.
+    tripoint entry_local = get_map().getlocal( entry_abs_ms );
+    tripoint safe_pos = find_safe_spawn( entry_local );
+    p.setpos( safe_pos );
+
+    // Single update_map call at the final position
+    g->update_map( p );
+}
+
+void iuse_pocket_dimension::exit_pocket( player &p, item &it ) const
+{
+    item::pocket_dimension_data *pd = it.get_pocket_dimension_data();
+    if( !pd ) {
+        return;
+    }
+
+    p.add_msg_if_player( m_good, _( "You exit the pocket dimension." ) );
+
+    // Clear the pocket dimension display name
+    g->set_pocket_dimension_name( "" );
+
+    // Compute destination submap position from return point so the map loads centered
+    // on the destination, avoiding a costly incremental shift in update_map()
+    tripoint_abs_sm dest_sm = project_to<coords::sm>( pd->return_point );
+
+    // Travel back to the return dimension (no bounds = infinite dimension)
+    // travel_to_dimension clears stale bounds before loading the map
+    g->travel_to_dimension( pd->return_dimension, pd->return_instance_id, std::nullopt, dest_sm );
+
+    // Teleport player to return point
+    // Convert return_point (OMT coords) to absolute map squares, then to local
+    tripoint_abs_ms return_abs_ms = project_to<coords::ms>( pd->return_point );
+    // Add offset to center of the OMT (OMT is 24x24 map squares)
+    return_abs_ms += tripoint( SEEX, SEEY, 0 );
+    // The map is already loaded centered on the destination (via load_pos parameter),
+    // so local coordinates are valid without needing a map shift first.
+    tripoint return_local = get_map().getlocal( return_abs_ms );
+    tripoint safe_pos = find_safe_spawn( return_local );
+    p.setpos( safe_pos );
+
+    // Single update_map call at the final position
+    g->update_map( p );
 }

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1506,7 +1506,7 @@ class iuse_flowerpot_collect final : public iuse_actor
 class iuse_dimension_travel : public iuse_actor
 {
     public:
-        std::string destination = "default";
+        world_type_id destination;
         int travel_radius = 1;
         int need_charges = 1;
         std::string fail_message;
@@ -1520,4 +1520,31 @@ class iuse_dimension_travel : public iuse_actor
         std::unique_ptr<iuse_actor> clone() const override;
     private:
         void dimension_travel( player &p, item &, const tripoint &pos ) const;
+};
+
+/**
+ * iuse_actor for items that function as keys to pocket dimensions.
+ * When used from the base dimension, enters the pocket.
+ * When used from inside the pocket, exits to the return point.
+ */
+class iuse_pocket_dimension : public iuse_actor
+{
+    public:
+        world_type_id pocket_type = world_type_id( "pocket_dimension" ); // Which world_type to use for this pocket
+        std::string entry_mapgen;               // Overmap special ID for generation
+        bool persistent = false;                 // Does the pocket survive item destruction?
+        int need_charges = 0;
+        std::optional<ter_str_id> boundary_terrain;  // Override boundary terrain for this pocket
+        std::string pocket_name;                 // Display name for this pocket on the overmap
+
+        iuse_pocket_dimension( const std::string &type = "pocket_dimension" ) : iuse_actor( type ) {}
+        ~iuse_pocket_dimension() override = default;
+        void load( const JsonObject &obj ) override;
+        int use( player &p, item &, bool, const tripoint & ) const override;
+        ret_val<bool> can_use( const Character &, const item &it, bool, const tripoint & ) const override;
+        std::unique_ptr<iuse_actor> clone() const override;
+    private:
+        void initialize_pocket( item &it ) const;
+        void enter_pocket( player &p, item &it ) const;
+        void exit_pocket( player &p, item &it ) const;
 };

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -138,6 +138,15 @@ bool map::build_transparency_cache( const int zlev )
 
             const point sm_offset = sm_to_ms_copy( point( smx, smy ) );
 
+            if( cur_submap == nullptr ) {
+                for( int sx = 0; sx < SEEX; ++sx ) {
+                    std::uninitialized_fill_n(
+                        &transparency_cache[sm_offset.x + sx][sm_offset.y], SEEY,
+                        LIGHT_TRANSPARENCY_SOLID );
+                }
+                continue;
+            }
+
             if( !rebuild_all && !map_cache.transparency_cache_dirty[smx * MAPSIZE + smy] ) {
                 continue;
             }
@@ -483,6 +492,9 @@ void map::generate_lightmap( const int zlev )
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
             const auto cur_submap = get_submap_at_grid( { smx, smy, zlev } );
+            if( cur_submap == nullptr ) {
+                continue;
+            }
 
             for( int sx = 0; sx < SEEX; ++sx ) {
                 for( int sy = 0; sy < SEEY; ++sy ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -214,6 +214,48 @@ map::map( int mapsize, bool zlev )
 map::~map() = default;
 map &map::operator=( map && )  noexcept = default;
 
+void map::set_dimension_bounds( const dimension_bounds &bounds )
+{
+    current_bounds_ = bounds;
+}
+
+void map::clear_dimension_bounds()
+{
+    current_bounds_.reset();
+}
+
+void map::clear_grid()
+{
+    std::fill( grid.begin(), grid.end(), nullptr );
+}
+
+bool map::has_dimension_bounds() const
+{
+    return current_bounds_.has_value();
+}
+
+bool map::is_out_of_bounds( const tripoint &p ) const
+{
+    if( !current_bounds_ ) {
+        return false;  // No bounds means infinite dimension
+    }
+    return !current_bounds_->contains_local( p, tripoint_abs_sm( abs_sub ) );
+}
+
+ter_id map::get_boundary_terrain() const
+{
+    if( current_bounds_ && current_bounds_->boundary_terrain.is_valid() ) {
+        return current_bounds_->boundary_terrain.id();
+    }
+    // Fallback to t_null if no boundary terrain is set
+    return t_null;
+}
+
+std::optional<dimension_bounds> map::get_dimension_bounds() const
+{
+    return current_bounds_;
+}
+
 void map::set_transparency_cache_dirty( const int zlev )
 {
     if( inbounds_z( zlev ) ) {
@@ -296,6 +338,9 @@ maptile map::maptile_at_internal( const tripoint &p ) const
 {
     point l;
     submap *const sm = get_submap_at( p, l );
+    if( sm == nullptr ) {
+        return maptile( &null_submap, point_zero );
+    }
 
     return maptile( sm, l );
 }
@@ -304,6 +349,9 @@ maptile map::maptile_at_internal( const tripoint &p )
 {
     point l;
     submap *const sm = get_submap_at( p, l );
+    if( sm == nullptr ) {
+        return maptile( &null_submap, point_zero );
+    }
 
     return maptile( sm, l );
 }
@@ -428,6 +476,9 @@ void map::clear_vehicle_list( const int zlev )
 
 void map::update_vehicle_list( const submap *const to, const int zlev )
 {
+    if( to == nullptr ) {
+        return;
+    }
     // Update vehicle data
     level_cache &ch = get_cache( zlev );
     for( const auto &elem : to->vehicles ) {
@@ -1119,6 +1170,9 @@ VehicleList map::get_vehicles( const tripoint &start, const tripoint &end )
         for( int cy = chunk_sy; cy <= chunk_ey; ++cy ) {
             for( int cz = chunk_sz; cz <= chunk_ez; ++cz ) {
                 submap *current_submap = get_submap_at_grid( { cx, cy, cz } );
+                if( current_submap == nullptr ) {
+                    continue;
+                }
                 for( const auto &elem : current_submap->vehicles ) {
                     // Ensure the vehicle z-position is correct
                     elem->sm_pos.z = cz;
@@ -1482,7 +1536,7 @@ bool map::has_furn( const tripoint &p ) const
 
 furn_id map::furn( const tripoint &p ) const
 {
-    if( !inbounds( p ) ) {
+    if( !inbounds( p ) || is_out_of_bounds( p ) ) {
         return f_null;
     }
 
@@ -1495,7 +1549,7 @@ furn_id map::furn( const tripoint &p ) const
 void map::furn_set( const tripoint &p, const furn_id &new_furniture,
                     const cata::poly_serialized<active_tile_data> &new_active )
 {
-    if( !inbounds( p ) ) {
+    if( !inbounds( p ) || is_out_of_bounds( p ) ) {
         return;
     }
 
@@ -1638,6 +1692,11 @@ std::string map::furnname( const tripoint &p )
  */
 ter_id map::ter( const tripoint &p ) const
 {
+    // Check dimension bounds first - out-of-bounds areas show boundary terrain
+    if( is_out_of_bounds( p ) ) {
+        return get_boundary_terrain();
+    }
+
     if( !inbounds( p ) ) {
         return t_null;
     }
@@ -1833,7 +1892,7 @@ bool map::is_harvestable( const tripoint &pos ) const
  */
 bool map::ter_set( const tripoint &p, const ter_id &new_terrain )
 {
-    if( !inbounds( p ) ) {
+    if( !inbounds( p ) || is_out_of_bounds( p ) ) {
         return false;
     }
 
@@ -1983,6 +2042,11 @@ bool map::is_wall_adjacent( const tripoint &center ) const
 
 int map::move_cost( const tripoint &p, const vehicle *ignored_vehicle ) const
 {
+    // Dimension bounds are always impassable
+    if( is_out_of_bounds( p ) ) {
+        return 0;
+    }
+
     if( !inbounds( p ) ) {
         return 0;
     }
@@ -2879,6 +2943,10 @@ void map::decay_fields_and_scent( const time_duration &amount )
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
             const auto cur_submap = get_submap_at_grid( { smx, smy, smz } );
+            if( cur_submap == nullptr ) {
+                get_cache( smz ).field_cache.reset( smx + ( smy * MAPSIZE ) );
+                continue;
+            }
             int to_proc = cur_submap->field_count;
             if( to_proc < 1 ) {
                 if( to_proc < 0 ) {
@@ -3809,6 +3877,18 @@ bash_results map::bash( const tripoint &p, const int str,
         str, silent, destroy, bash_floor, static_cast<float>( rng_float( 0, 1.0f ) ), false, true
     };
     bash_results result;
+
+    // Dimension bounds cannot be bashed - show message from boundary terrain
+    if( is_out_of_bounds( p ) ) {
+        if( !silent && current_bounds_ ) {
+            const ter_t &boundary_ter = current_bounds_->boundary_terrain.obj();
+            if( !boundary_ter.bash.sound_fail.empty() ) {
+                add_msg( m_info, boundary_ter.bash.sound_fail.translated() );
+            }
+        }
+        return result;  // Cannot bash dimension boundary
+    }
+
     if( !inbounds( p ) ) {
         return result;
     }
@@ -3915,6 +3995,11 @@ bash_results &bash_results::operator|=( const bash_results &other )
 
 void map::destroy( const tripoint &p, const bool silent )
 {
+    // Dimension bounds cannot be destroyed
+    if( is_out_of_bounds( p ) ) {
+        return;
+    }
+
     // Break if it takes more than 25 destructions to remove to prevent infinite loops
     // Example: A bashes to B, B bashes to A leads to A->B->A->...
 
@@ -4622,20 +4707,28 @@ void map::adjust_radiation( const tripoint &p, const int delta )
 
 int map::get_temperature( const tripoint &p ) const
 {
-    if( !inbounds( p ) ) {
+    if( !inbounds( p ) || is_out_of_bounds( p ) ) {
         return 0;
     }
 
-    return get_submap_at( p )->get_temperature();
+    const submap *sm = get_submap_at( p );
+    if( !sm ) {
+        return 0;
+    }
+    return sm->get_temperature();
 }
 
 void map::set_temperature( const tripoint &p, int new_temperature )
 {
-    if( !inbounds( p ) ) {
+    if( !inbounds( p ) || is_out_of_bounds( p ) ) {
         return;
     }
 
-    get_submap_at( p )->set_temperature( new_temperature );
+    submap *sm = get_submap_at( p );
+    if( !sm ) {
+        return;
+    }
+    sm->set_temperature( new_temperature );
 }
 // Items: 3D
 
@@ -4782,6 +4875,12 @@ void map::spawn_item( const tripoint &p, const itype_id &type_id,
     if( item_is_blacklisted( type_id ) ) {
         return;
     }
+
+    // Skip spawning items in dimension-bounded out-of-bounds areas
+    if( is_out_of_bounds( p ) ) {
+        return;
+    }
+
     for( size_t i = 0; i < quantity; i++ ) {
         // spawn the item
         detached_ptr<item> new_item = item::spawn( type_id, birthday );
@@ -4824,6 +4923,11 @@ detached_ptr<item> map::add_item_or_charges( const tripoint &pos, detached_ptr<i
             // should never happen
             debugmsg( "add_item_or_charges: %s is out of bounds (adding item '%s' [%d])",
                       e.to_string(), obj->typeId().c_str(), obj->charges );
+            return false;
+        }
+
+        // Cannot add items to dimension-bounded out-of-bounds areas
+        if( is_out_of_bounds( e ) ) {
             return false;
         }
 
@@ -5134,6 +5238,9 @@ std::vector<tripoint> map::check_submap_active_item_consistency()
             for( int y = 0; y < MAPSIZE; ++y ) {
                 tripoint p( x, y, z );
                 submap *s = get_submap_at_grid( p );
+                if( s == nullptr ) {
+                    continue;
+                }
                 bool has_active_items = !s->active_items.get().empty();
                 bool map_has_active_items = submaps_with_active_items.contains( p + abs_sub.xy() );
                 if( has_active_items != map_has_active_items ) {
@@ -5165,6 +5272,9 @@ void map::process_items()
         }
         for( const tripoint &pos : submaps_with_vehicles ) {
             submap *const current_submap = get_submap_at_grid( pos );
+            if( current_submap == nullptr ) {
+                continue;
+            }
             // Vehicles first in case they get blown up and drop active items on the map.
             process_items_in_vehicles( *current_submap );
         }
@@ -5174,6 +5284,9 @@ void map::process_items()
     for( const tripoint &abs_pos : submaps_with_active_items_copy ) {
         const tripoint local_pos = abs_pos - abs_sub.xy();
         submap *const current_submap = get_submap_at_grid( local_pos );
+        if( current_submap == nullptr ) {
+            continue;
+        }
         if( !current_submap->active_items.empty() ) {
             process_items_in_submap( *current_submap, local_pos );
         }
@@ -5631,12 +5744,16 @@ bool map::can_see_trap_at( const tripoint &p, const Character &c ) const
 
 const trap &map::tr_at( const tripoint &p ) const
 {
-    if( !inbounds( p ) ) {
+    if( !inbounds( p ) || is_out_of_bounds( p ) ) {
         return tr_null.obj();
     }
 
     point l;
     submap *const current_submap = get_submap_at( p, l );
+
+    if( current_submap == nullptr ) {
+        return tr_null.obj();
+    }
 
     if( current_submap->get_ter( l ).obj().trap != tr_null ) {
         return current_submap->get_ter( l ).obj().trap.obj();
@@ -5647,7 +5764,7 @@ const trap &map::tr_at( const tripoint &p ) const
 
 partial_con *map::partial_con_at( const tripoint &p )
 {
-    if( !inbounds( p ) ) {
+    if( !inbounds( p ) || is_out_of_bounds( p ) ) {
         return nullptr;
     }
     point l;
@@ -5661,7 +5778,7 @@ partial_con *map::partial_con_at( const tripoint &p )
 
 void map::partial_con_remove( const tripoint &p )
 {
-    if( !inbounds( p ) ) {
+    if( !inbounds( p ) || is_out_of_bounds( p ) ) {
         return;
     }
     point l;
@@ -5671,7 +5788,7 @@ void map::partial_con_remove( const tripoint &p )
 
 void map::partial_con_set( const tripoint &p, std::unique_ptr<partial_con> con )
 {
-    if( !inbounds( p ) ) {
+    if( !inbounds( p ) || is_out_of_bounds( p ) ) {
         return;
     }
     point l;
@@ -5792,13 +5909,18 @@ void map::remove_trap( const tripoint &p )
  */
 const field &map::field_at( const tripoint &p ) const
 {
-    if( !inbounds( p ) ) {
+    if( !inbounds( p ) || is_out_of_bounds( p ) ) {
         nulfield = field();
         return nulfield;
     }
 
     point l;
     submap *const current_submap = get_submap_at( p, l );
+
+    if( current_submap == nullptr ) {
+        nulfield = field();
+        return nulfield;
+    }
 
     return current_submap->get_field( l );
 }
@@ -5808,13 +5930,18 @@ const field &map::field_at( const tripoint &p ) const
  */
 field &map::field_at( const tripoint &p )
 {
-    if( !inbounds( p ) ) {
+    if( !inbounds( p ) || is_out_of_bounds( p ) ) {
         nulfield = field();
         return nulfield;
     }
 
     point l;
     submap *const current_submap = get_submap_at( p, l );
+
+    if( current_submap == nullptr ) {
+        nulfield = field();
+        return nulfield;
+    }
 
     return current_submap->get_field( l );
 }
@@ -7088,6 +7215,7 @@ void map::save()
 
 void map::load( const tripoint &w, const bool update_vehicle, const bool pump_events )
 {
+    std::fill( grid.begin(), grid.end(), nullptr );
     for( auto &traps : traplocs ) {
         traps.clear();
     }
@@ -7417,6 +7545,15 @@ void map::vertical_shift( const int newz )
 void map::saven( const tripoint &grid )
 {
     dbg( DL::Debug ) << "map::saven( world=" << abs_sub << ", grid=" << grid << " )";
+
+    // Skip saving submaps outside dimension bounds - they are generated on load
+    if( current_bounds_ ) {
+        const tripoint grid_abs_sub = abs_sub.xy() + grid;
+        if( !current_bounds_->contains( tripoint_abs_sm( grid_abs_sub ) ) ) {
+            return;
+        }
+    }
+
     const int gridn = get_nonant( grid );
     submap *submap_to_save = getsubmap( gridn );
     if( submap_to_save == nullptr || submap_to_save->get_ter( point_zero ) == t_null ) {
@@ -7478,10 +7615,41 @@ void map::loadn( const tripoint &grid, const bool update_vehicles )
     const tripoint grid_abs_sub = abs_sub.xy() + grid;
     const size_t gridn = get_nonant( grid );
 
+    // For out-of-bounds areas in bounded dimensions, use uniform boundary terrain submaps
+    // instead of nullptr, to prevent null submap access crashes in grid iteration code.
+    // IMPORTANT: We check the in-memory submap map directly instead of calling
+    // MAPBUFFER.lookup_submap(), because lookup_submap() queries the SQLite database
+    // on cache miss. For pocket dimensions, ~2400 of ~2541 submaps are out-of-bounds,
+    // so avoiding those DB queries is a major performance win.
+    if( current_bounds_ && !current_bounds_->contains( tripoint_abs_sm( grid_abs_sub ) ) ) {
+        submap *bsub = MAPBUFFER.lookup_submap_in_memory( grid_abs_sub );
+        // Diagnostic: log boundary submap creation for dimension debugging
+        if( bsub == nullptr ) {
+            add_msg( m_debug, "[DIM-DIAG] loadn: creating boundary submap at (%d,%d,%d)",
+                     grid_abs_sub.x, grid_abs_sub.y, grid_abs_sub.z );
+            auto sm = std::make_unique<submap>( sm_to_ms_copy( grid_abs_sub ) );
+            sm->is_uniform = true;
+            sm->set_all_ter( get_boundary_terrain() );
+            sm->last_touched = calendar::turn;
+            MAPBUFFER.add_submap( grid_abs_sub, sm );
+            bsub = MAPBUFFER.lookup_submap_in_memory( grid_abs_sub );
+        }
+        if( bsub != nullptr ) {
+            setsubmap( gridn, bsub );
+        }
+        return;
+    }
+
     const int old_abs_z = abs_sub.z; // Ugly, but necessary at the moment
     abs_sub.z = grid.z;
 
     submap *tmpsub = MAPBUFFER.lookup_submap( grid_abs_sub );
+    // Diagnostic: log in-bounds submap loading for dimension transition debugging
+    if( current_bounds_ ) {
+        add_msg( m_debug, "[DIM-DIAG] loadn: in-bounds submap at (%d,%d,%d) %s",
+                 grid_abs_sub.x, grid_abs_sub.y, grid_abs_sub.z,
+                 tmpsub ? "found" : "MISSING - will generate" );
+    }
     if( tmpsub == nullptr ) {
         // It doesn't exist; we must generate it!
         dbg( DL::Info ) << "map::loadn: Missing mapbuffer data.  Regenerating.";
@@ -7571,6 +7739,16 @@ void map::remove_rotten_items( Container &items, const tripoint &pnt, temperatur
 {
     std::vector<item *> corpses_handle;
     items.remove_with( [this, &pnt, &temperature, &corpses_handle]( detached_ptr<item> &&it ) {
+        // Validate item pointer before access to catch use-after-free corruption
+        // from stale pointers surviving dimension transitions.
+        if( !it ) {
+            debugmsg( "remove_rotten_items: null item pointer at %s", pnt.to_string() );
+            return std::move( it );
+        }
+        if( !it->type ) {
+            debugmsg( "remove_rotten_items: item with null type at %s", pnt.to_string() );
+            return std::move( it );
+        }
         item &obj = *it;
         it = item::actualize_rot( std::move( it ), pnt, temperature, get_weather() );
         // When !it, that means the item was removed from the world, ie: has rotted.
@@ -7978,6 +8156,15 @@ void map::actualize( const tripoint &grid )
         return;
     }
 
+    // Skip uniform boundary submaps - they have no items or meaningful state to actualize
+    // and accessing their tile data through map accessors could hit invalid state during
+    // dimension transitions.
+    const tripoint grid_abs = abs_sub.xy() + grid;
+    if( tmpsub->is_uniform && current_bounds_ &&
+        !current_bounds_->contains( tripoint_abs_sm( grid_abs ) ) ) {
+        return;
+    }
+
     const time_duration time_since_last_actualize = calendar::turn - tmpsub->last_touched;
     const bool do_funnels = ( grid.z >= 0 );
 
@@ -8035,8 +8222,11 @@ void map::add_roofs( const tripoint &grid )
 
     submap *const sub_here = get_submap_at_grid( grid );
     if( sub_here == nullptr ) {
-        debugmsg( "Tried to add roofs/floors on null submap on %d,%d,%d",
-                  grid.x, grid.y, grid.z );
+        // Null submaps are expected for out-of-bounds areas in bounded pocket dimensions
+        if( !has_dimension_bounds() ) {
+            debugmsg( "Tried to add roofs/floors on null submap on %d,%d,%d",
+                      grid.x, grid.y, grid.z );
+        }
         return;
     }
 
@@ -8045,8 +8235,10 @@ void map::add_roofs( const tripoint &grid )
     submap *const sub_below = check_roof ? get_submap_at_grid( grid + tripoint_below ) : nullptr;
 
     if( check_roof && sub_below == nullptr ) {
-        debugmsg( "Tried to add roofs to sm at %d,%d,%d, but sm below doesn't exist",
-                  grid.x, grid.y, grid.z );
+        if( !has_dimension_bounds() ) {
+            debugmsg( "Tried to add roofs to sm at %d,%d,%d, but sm below doesn't exist",
+                      grid.x, grid.y, grid.z );
+        }
         return;
     }
 
@@ -8076,6 +8268,9 @@ void map::copy_grid( const tripoint &to, const tripoint &from )
 {
     const auto smap = get_submap_at_grid( from );
     setsubmap( get_nonant( to ), smap );
+    if( smap == nullptr ) {
+        return;
+    }
     for( auto &it : smap->vehicles ) {
         it->sm_pos = to;
     }
@@ -8109,6 +8304,9 @@ void map::spawn_monsters_submap_group( const tripoint &gp, mongroup &group, bool
 
     // If the submap is uniform, we can skip many checks
     const submap *current_submap = get_submap_at_grid( gp );
+    if( current_submap == nullptr ) {
+        return;
+    }
     bool ignore_terrain_checks = false;
     bool ignore_inside_checks = gp.z < 0;
     if( current_submap->is_uniform ) {
@@ -8229,6 +8427,9 @@ void map::spawn_monsters_submap( const tripoint &gp, bool ignore_sight )
     }
 
     submap *const current_submap = get_submap_at_grid( gp );
+    if( current_submap == nullptr ) {
+        return;
+    }
     const tripoint gp_ms = sm_to_ms_copy( gp );
 
     for( auto &i : current_submap->spawns ) {
@@ -8500,6 +8701,9 @@ void map::build_outside_cache( const int zlev )
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
             const auto cur_submap = get_submap_at_grid( { smx, smy, zlev } );
+            if( cur_submap == nullptr ) {
+                continue;
+            }
 
             for( int sx = 0; sx < SEEX; ++sx ) {
                 for( int sy = 0; sy < SEEY; ++sy ) {
@@ -8542,6 +8746,14 @@ void map::build_obstacle_cache( const tripoint &start, const tripoint &end,
     for( int smx = min_submap.x; smx <= max_submap.x; ++smx ) {
         for( int smy = min_submap.y; smy <= max_submap.y; ++smy ) {
             const auto cur_submap = get_submap_at_grid( { smx, smy, start.z } );
+            if( cur_submap == nullptr ) {
+                for( int sx = 0; sx < SEEX; ++sx ) {
+                    for( int sy = 0; sy < SEEY; ++sy ) {
+                        obstacle_cache[sx + smx * SEEX][sy + smy * SEEY] = 1000.0f;
+                    }
+                }
+                continue;
+            }
 
             // TODO: Init indices to prevent iterating over unused submap sections.
             for( int sx = 0; sx < SEEX; ++sx ) {
@@ -8599,12 +8811,16 @@ bool map::build_floor_cache( const int zlev )
             const submap *below_submap = !lowest_z_lev ? get_submap_at_grid( { smx, smy, zlev - 1 } ) : nullptr;
 
             if( cur_submap == nullptr ) {
-                debugmsg( "Tried to build floor cache at (%d,%d,%d) but the submap is not loaded", smx, smy, zlev );
+                if( !has_dimension_bounds() ) {
+                    debugmsg( "Tried to build floor cache at (%d,%d,%d) but the submap is not loaded", smx, smy, zlev );
+                }
                 continue;
             }
             if( !lowest_z_lev && below_submap == nullptr ) {
-                debugmsg( "Tried to build floor cache at (%d,%d,%d) but the submap is not loaded", smx, smy,
-                          zlev - 1 );
+                if( !has_dimension_bounds() ) {
+                    debugmsg( "Tried to build floor cache at (%d,%d,%d) but the submap is not loaded", smx, smy,
+                              zlev - 1 );
+                }
                 continue;
             }
 
@@ -8653,8 +8869,10 @@ void map::update_suspension_cache( const int &z )
                 const submap *cur_submap = get_submap_at_grid( { smx, smy, z } );
 
                 if( cur_submap == nullptr ) {
-                    debugmsg( "Tried to run suspension check at (%d,%d,%d) but the submap is not loaded", smx, smy,
-                              z );
+                    if( !has_dimension_bounds() ) {
+                        debugmsg( "Tried to run suspension check at (%d,%d,%d) but the submap is not loaded", smx, smy,
+                                  z );
+                    }
                     continue;
                 }
 
@@ -8899,9 +9117,6 @@ void map::setsubmap( const size_t grididx, submap *const smap )
     if( grididx >= grid.size() ) {
         debugmsg( "Tried to access invalid grid index %d", grididx );
         return;
-    } else if( smap == nullptr ) {
-        debugmsg( "Tried to set NULL submap pointer at index %d", grididx );
-        return;
     }
     grid[grididx] = smap;
 }
@@ -9117,6 +9332,11 @@ void map::function_over( const tripoint &start, const tripoint &end, Functor fun
         for( smx = min_sm.x; smx <= max_sm.x; smx++ ) {
             for( smy = min_sm.y; smy <= max_sm.y; smy++ ) {
                 submap const *cur_submap = get_submap_at_grid( { smx, smy, z } );
+                if( cur_submap == nullptr ) {
+                    // This can happen in pocket dimensions where out-of-bounds
+                    // submaps are intentionally set to null
+                    continue;
+                }
                 // Bounds on the submap coordinates
                 const point sm_min( smx > min_sm.x ? 0 : min.x % SEEX, smy > min_sm.y ? 0 : min.y % SEEY );
                 const point sm_max( smx < max_sm.x ? SEEX - 1 : max.x % SEEX,
@@ -9263,6 +9483,9 @@ std::vector<item *> map::get_active_items_in_radius( const tripoint &center, int
         const point sm_offset( submap_loc.x * SEEX, submap_loc.y * SEEY );
 
         submap *sm = get_submap_at_grid( submap_loc );
+        if( sm == nullptr ) {
+            continue;
+        }
         std::vector<item *> items = type == special_item_type::none ? sm->active_items.get() :
                                     sm->active_items.get_special( type );
         for( const auto &elem : items ) {
@@ -9641,7 +9864,7 @@ int map::calc_max_populated_zlev()
         for( int sx = 0; sx < my_MAPSIZE; sx++ ) {
             for( int sy = 0; sy < my_MAPSIZE; sy++ ) {
                 const submap *sm = get_submap_at_grid( tripoint( sx, sy, sz ) );
-                if( !sm->is_uniform ) {
+                if( sm == nullptr || !sm->is_uniform ) {
                     max_z = sz;
                     level_done = true;
                     break;

--- a/src/map.h
+++ b/src/map.h
@@ -19,6 +19,7 @@
 #include "calendar.h"
 #include "coordinate_conversions.h"
 #include "coordinates.h"
+#include "dimension_bounds.h"
 #include "enums.h"
 #include "filter_utils.h"
 #include "game_constants.h"
@@ -395,6 +396,41 @@ class map
 
         map &operator=( const map & ) = delete;
         map &operator=( map && ) noexcept ;
+
+        // Dimension Bounds (for bounded pocket dimensions)
+        /**
+         * Set the dimension bounds for this map.
+         * Out-of-bounds areas will be rendered as boundary terrain and are impassable.
+         */
+        void set_dimension_bounds( const dimension_bounds &bounds );
+        /**
+         * Clear the dimension bounds (for infinite dimensions).
+         */
+        void clear_dimension_bounds();
+        /**
+         * Clear all grid submap pointers (set to nullptr).
+         * Must be called before clearing MAPBUFFER to prevent dangling pointers.
+         */
+        void clear_grid();
+        /**
+         * Check if the map has dimension bounds set.
+         */
+        bool has_dimension_bounds() const;
+        /**
+         * Check if a local tripoint is out of dimension bounds.
+         * Returns false if no bounds are set (infinite dimension).
+         */
+        bool is_out_of_bounds( const tripoint &p ) const;
+        /**
+         * Get the boundary terrain ID for out-of-bounds areas.
+         * Only valid if has_dimension_bounds() is true.
+         */
+        ter_id get_boundary_terrain() const;
+        /**
+         * Get the current dimension bounds (if any).
+         * Returns the full bounds structure for secondary world capture.
+         */
+        std::optional<dimension_bounds> get_dimension_bounds() const;
 
         /**
          * Sets a dirty flag on the a given cache.
@@ -2080,6 +2116,9 @@ class map
         // caches the highest zlevel above which all zlevels are uniform
         // !value || value->first != map::abs_sub means cache is invalid
         std::optional<std::pair<tripoint, int>> max_populated_zlev = std::nullopt;
+
+        // Dimension bounds for bounded pocket dimensions (nullopt for infinite dimensions)
+        std::optional<dimension_bounds> current_bounds_;
 
     public:
         bool has_rope_at( tripoint pt ) const;

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -153,6 +153,9 @@ void map::process_fields()
             for( int y = 0; y < my_MAPSIZE; y++ ) {
                 if( field_cache[ x + y * MAPSIZE ] ) {
                     submap *const current_submap = get_submap_at_grid( { x, y, z } );
+                    if( current_submap == nullptr ) {
+                        continue;
+                    }
                     process_fields_in_submap( current_submap, tripoint( x, y, z ) );
                 }
             }
@@ -436,6 +439,11 @@ void map::process_fields_in_submap( submap *const current_submap,
             thep.y = locy + sm_offset.y;
             // A const reference to the tripoint above, so that the code below doesn't accidentally change it
             const tripoint &p = thep;
+
+            // Skip simulation for out-of-bounds areas (pocket dimension boundaries)
+            if( here.is_out_of_bounds( p ) ) {
+                continue;
+            }
 
             // This should be true only when the field in the current tile changes transparency state,
             // More correctly: not just when the field is opaque, but when it changes state
@@ -1202,7 +1210,8 @@ void map::process_fields_in_submap( submap *const current_submap,
         auto &field_cache = get_cache( z ).field_cache;
         for( int y = std::max( submap.y - 1, 0 ); y <= std::min( submap.y + 1, MAPSIZE - 1 ); ++y ) {
             for( int x = std::max( submap.x - 1, 0 ); x <= std::min( submap.x + 1, MAPSIZE - 1 ); ++x ) {
-                if( get_submap_at_grid( { x, y, z } )->field_count > 0 ) {
+                const struct submap *sm = get_submap_at_grid( { x, y, z } );
+                if( sm != nullptr && sm->field_count > 0 ) {
                     field_cache.set( x + y * MAPSIZE );
                 } else {
                     field_cache.reset( x + y * MAPSIZE );

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -56,6 +56,16 @@ class mapbuffer
             return lookup_submap( p.raw() );
         }
 
+        /** Get a submap only if it's already loaded in memory.
+         * Unlike lookup_submap(), this does NOT query the database for missing submaps.
+         * Use this for out-of-bounds positions where we know there's no DB entry,
+         * to avoid ~2400 wasted SQLite queries per pocket dimension map load.
+         */
+        submap *lookup_submap_in_memory( const tripoint &p ) {
+            const auto iter = submaps.find( p );
+            return iter != submaps.end() ? iter->second.get() : nullptr;
+        }
+
     private:
         using submap_map_t = std::map<tripoint, std::unique_ptr<submap>>;
 

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -761,7 +761,9 @@ ter_id t_null,
        t_railroad_track, t_railroad_track_h, t_railroad_track_v, t_railroad_track_d, t_railroad_track_d1,
        t_railroad_track_d2,
        t_railroad_track_on_tie, t_railroad_track_h_on_tie, t_railroad_track_v_on_tie,
-       t_railroad_track_d_on_tie;
+       t_railroad_track_d_on_tie,
+       t_pd_border,
+       t_rock_border;
 
 // TODO: Put this crap into an inclusion, which should be generated automatically using JSON data
 
@@ -1072,6 +1074,8 @@ void set_ter_ids()
     t_railroad_track_h_on_tie = ter_id( "t_railroad_track_h_on_tie" );
     t_railroad_track_v_on_tie = ter_id( "t_railroad_track_v_on_tie" );
     t_railroad_track_d_on_tie = ter_id( "t_railroad_track_d_on_tie" );
+    t_pd_border = ter_id("t_pd_border");
+    t_rock_border = ter_id("t_rock_border");
 
     for( auto &elem : terrain_data.get_all() ) {
         ter_t &ter = const_cast<ter_t &>( elem );

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -773,7 +773,9 @@ extern ter_id t_null,
        t_railroad_track, t_railroad_track_h, t_railroad_track_v, t_railroad_track_d, t_railroad_track_d1,
        t_railroad_track_d2,
        t_railroad_track_on_tie, t_railroad_track_h_on_tie, t_railroad_track_v_on_tie,
-       t_railroad_track_d_on_tie;
+       t_railroad_track_d_on_tie,
+       t_pd_border,
+       t_rock_border;
 
 /*
 runtime index: furn_id

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -137,6 +137,7 @@ building_gen_pointer get_mapgen_cfunction( const std::string &ident )
 
             { "tutorial", &mapgen_tutorial },
             { "lake_shore", &mapgen_lake_shore },
+            { "pd_border", &mapgen_pd_border },
         }
     };
     const auto iter = pointers.find( ident );
@@ -1925,6 +1926,20 @@ void mapgen_rock( mapgendata &dat )
 void mapgen_open_air( mapgendata &dat )
 {
     fill_background( &dat.m, t_open_air );
+}
+
+void mapgen_pd_border( mapgendata &dat )
+{
+    // Use the boundary terrain from the map's dimension bounds if available,
+    // otherwise fall back to the default pocket dimension border terrain.
+    ter_id border_ter = ter_id( "t_pd_border" );
+    if( dat.m.has_dimension_bounds() ) {
+        std::optional<dimension_bounds> bounds = dat.m.get_dimension_bounds();
+        if( bounds && bounds->boundary_terrain.is_valid() ) {
+            border_ter = bounds->boundary_terrain.id();
+        }
+    }
+    fill_background( &dat.m, border_ter );
 }
 
 void mapgen_rift( mapgendata &dat )

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -60,6 +60,7 @@ void mapgen_cavern( mapgendata &dat );
 void mapgen_rock( mapgendata &dat );
 void mapgen_rock_partial( mapgendata &dat );
 void mapgen_open_air( mapgendata &dat );
+void mapgen_pd_border( mapgendata &dat );
 void mapgen_rift( mapgendata &dat );
 void mapgen_hellmouth( mapgendata &dat );
 void mapgen_subway( mapgendata &dat );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2829,6 +2829,22 @@ void options_manager::add_options_world_default()
 
     add_empty_line();
 
+    add( "POCKET_SIMULATION_LEVEL", world_default, translate_marker( "Pocket Dimension Simulation" ),
+         translate_marker( "How to handle the last visited pocket dimension. "
+                           "'Off' unloads normally. 'None' keeps loaded but frozen for fast travel. "
+                           "'Minimal' simulates fields only (fire, gas). "
+                           "'Moderate' adds vehicle systems (solar charging). "
+                           "'Full' simulates everything including off-screen combat." ),
+    {   { "off", translate_marker( "Off" ) },
+        { "none", translate_marker( "None (Fast Travel)" ) },
+        { "minimal", translate_marker( "Minimal (Fields)" ) },
+        { "moderate", translate_marker( "Moderate (Fields + Vehicles)" ) },
+        { "full", translate_marker( "Full (Everything)" ) }
+    },
+    "off" );
+
+    add_empty_line();
+
     add( "CHARACTER_POINT_POOLS", world_default, translate_marker( "Character point pools" ),
          translate_marker( "Allowed point pools for character generation." ),
     { { "any", translate_marker( "Any" ) }, { "multi_pool", translate_marker( "Multi-pool only" ) }, { "no_freeform", translate_marker( "No freeform" ) } },

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -69,6 +69,7 @@
 #include "type_id.h"
 #include "weighted_list.h"
 #include "world.h"
+#include "world_type.h"
 
 static const efftype_id effect_pet( "pet" );
 
@@ -3353,6 +3354,13 @@ void overmap::generate( const overmap *north, const overmap *east,
 {
     if( g->gametype() == special_game_type::DEFENSE ) {
         dbg( DL::Info ) << "overmap::generate skipped in Defense special game mode!";
+        return;
+    }
+
+    const world_type_id &current_wt = g->get_current_world_type();
+    if( current_wt.is_valid() && !current_wt.obj().generate_overmap ) {
+        dbg( DL::Info ) << "overmap::generate skipped for world_type '" << current_wt.str()
+                        << "' (generate_overmap=false)";
         return;
     }
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -76,6 +76,7 @@
 #include "vpart_position.h"
 #include "weather.h"
 #include "weather_gen.h"
+#include "world_type.h"
 
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 
@@ -1482,6 +1483,15 @@ static void draw_om_sidebar(
         print_hint( "HELP_KEYBINDINGS" );
         print_hint( "QUIT" );
     }
+
+    // Display dimension name above the coordinate line
+    // Prefer the pocket dimension name from the iuse JSON definition if available
+    std::string dim_name = g->get_pocket_dimension_name();
+    if( dim_name.empty() ) {
+        const world_type &wt = g->get_current_world_type().obj();
+        dim_name = wt.name.translated();
+    }
+    mvwprintz( wbar, point( 1, getmaxy( wbar ) - 2 ), c_cyan, dim_name );
 
     mvwprintz( wbar, point( 1, getmaxy( wbar ) - 1 ), c_red, _( "LEVEL %i, %s" ), center.z(),
                fmt_omt_coords( center ) );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -282,6 +282,7 @@ void overmapbuffer::clear()
     overmaps.clear();
     known_non_existing.clear();
     placed_unique_specials.clear();
+    current_bounds_.reset();
 }
 
 const regional_settings &overmapbuffer::get_settings( const tripoint_abs_omt &p )
@@ -736,8 +737,22 @@ void overmapbuffer::add_vehicle( vehicle *veh )
     veh->om_id = id;
 }
 
+void overmapbuffer::set_dimension_bounds( const dimension_bounds &bounds )
+{
+    current_bounds_ = bounds;
+    bounds_oter_id_ = bounds.boundary_overmap_terrain.id();
+}
+
+void overmapbuffer::clear_dimension_bounds()
+{
+    current_bounds_.reset();
+}
+
 bool overmapbuffer::seen( const tripoint_abs_omt &p )
 {
+    if( current_bounds_ && !current_bounds_->contains_omt( p ) ) {
+        return true;
+    }
     if( const overmap_with_local_coords om_loc = get_existing_om_global( p ) ) {
         return om_loc.om->seen( om_loc.local );
     }
@@ -756,12 +771,18 @@ void overmapbuffer::set_seen( const tripoint_abs_omt &p, bool seen )
 
 const oter_id &overmapbuffer::ter( const tripoint_abs_omt &p )
 {
+    if( current_bounds_ && !current_bounds_->contains_omt( p ) ) {
+        return bounds_oter_id_;
+    }
     const overmap_with_local_coords om_loc = get_om_global( p );
     return om_loc.om->ter( om_loc.local );
 }
 
 const oter_id &overmapbuffer::ter_existing( const tripoint_abs_omt &p )
 {
+    if( current_bounds_ && !current_bounds_->contains_omt( p ) ) {
+        return bounds_oter_id_;
+    }
     static const oter_id ot_null;
     const overmap_with_local_coords om_loc = get_existing_om_global( p );
     if( !om_loc.om ) {

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -13,6 +13,7 @@
 #include <shared_mutex>
 
 #include "coordinates.h"
+#include "dimension_bounds.h"
 #include "enums.h"
 #include "json.h"
 #include "memory_fast.h"
@@ -171,6 +172,16 @@ class overmapbuffer
         void save();
         void clear();
         void create_custom_overmap( const point_abs_om &, overmap_special_batch &specials );
+
+        /**
+         * Set dimension bounds for pocket dimension overmap rendering.
+         * When set, tiles outside the bounds return boundary overmap terrain.
+         */
+        void set_dimension_bounds( const dimension_bounds &bounds );
+        /**
+         * Clear dimension bounds (e.g. when exiting a pocket dimension).
+         */
+        void clear_dimension_bounds();
 
         /**
         * Generates overmap tiles, if missing
@@ -543,6 +554,11 @@ class overmapbuffer
          * to not exist on disk. See @ref get_existing for usage.
          */
         std::set<point_abs_om> known_non_existing;
+
+        // Optional dimension bounds for pocket dimension rendering
+        std::optional<dimension_bounds> current_bounds_;
+        // Cached resolved overmap terrain id for out-of-bounds tiles
+        oter_id bounds_oter_id_;
 
         // Set of globally unique overmap specials that have already been placed
         std::unordered_set<overmap_special_id> placed_unique_specials;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -43,6 +43,8 @@
 #include "translations.h"
 #include "ui_manager.h"
 #include "weather.h"
+#include "world_type.h"
+#include "dimension_bounds.h"
 
 #if defined(__ANDROID__)
 #include "input.h"
@@ -98,6 +100,38 @@ void game::serialize( std::ostream &fout )
     json.member( "levz", pos_sm.z );
     json.member( "om_x", pos_om.x );
     json.member( "om_y", pos_om.y );
+
+    // Save the current world type (dimension)
+    json.member( "world_type", get_current_world_type() );
+    // Save pocket dimension instance ID (empty string for non-pocket dimensions)
+    json.member( "pocket_instance_id", get_pocket_instance_id() );
+
+    // Save pocket origin position and display name (when inside a pocket)
+    if( !get_pocket_instance_id().empty() ) {
+        tripoint_abs_sm origin = get_pocket_origin_position();
+        json.member( "pocket_origin_x", origin.x() );
+        json.member( "pocket_origin_y", origin.y() );
+        json.member( "pocket_origin_z", origin.z() );
+        json.member( "pocket_dimension_name", get_pocket_dimension_name() );
+    }
+
+    // Save dimension bounds for bounded dimensions (pocket dimensions)
+    if( m.has_dimension_bounds() ) {
+        std::optional<dimension_bounds> bounds = m.get_dimension_bounds();
+        if( bounds ) {
+            json.member( "dimension_bounds" );
+            json.start_object();
+            json.member( "min_x", bounds->min_bound.x() );
+            json.member( "min_y", bounds->min_bound.y() );
+            json.member( "min_z", bounds->min_bound.z() );
+            json.member( "max_x", bounds->max_bound.x() );
+            json.member( "max_y", bounds->max_bound.y() );
+            json.member( "max_z", bounds->max_bound.z() );
+            json.member( "boundary_terrain", bounds->boundary_terrain.str() );
+            json.member( "boundary_overmap_terrain", bounds->boundary_overmap_terrain.str() );
+            json.end_object();
+        }
+    }
 
     json.member( "grscent", scent.serialize() );
     json.member( "typescent", scent.serialize( true ) );
@@ -212,6 +246,53 @@ void game::unserialize( std::istream &fin )
         data.read( "levz", lev.z );
         data.read( "om_x", com.x );
         data.read( "om_y", com.y );
+
+        // Load the current world type (dimension) before load_map
+        // so get_dimension_prefix() returns the correct value
+        if( data.has_member( "world_type" ) ) {
+            world_type_id wt;
+            data.read( "world_type", wt );
+            set_current_world_type( wt );
+        }
+        // Load pocket instance ID if present
+        if( data.has_member( "pocket_instance_id" ) ) {
+            std::string pocket_id;
+            data.read( "pocket_instance_id", pocket_id );
+            set_pocket_instance_id( pocket_id );
+        }
+
+        // Load pocket origin position and display name if present
+        if( data.has_member( "pocket_origin_x" ) ) {
+            set_pocket_origin_position( tripoint_abs_sm(
+                                            data.get_int( "pocket_origin_x" ),
+                                            data.get_int( "pocket_origin_y" ),
+                                            data.get_int( "pocket_origin_z" ) ) );
+        }
+        if( data.has_member( "pocket_dimension_name" ) ) {
+            std::string pdname;
+            data.read( "pocket_dimension_name", pdname );
+            set_pocket_dimension_name( pdname );
+        }
+
+        // Load dimension bounds BEFORE load_map so loadn() can generate
+        // boundary submaps for out-of-bounds areas
+        if( data.has_object( "dimension_bounds" ) ) {
+            JsonObject bounds_obj = data.get_object( "dimension_bounds" );
+            dimension_bounds bounds;
+            bounds.min_bound = tripoint_abs_sm(
+                                   bounds_obj.get_int( "min_x" ),
+                                   bounds_obj.get_int( "min_y" ),
+                                   bounds_obj.get_int( "min_z" ) );
+            bounds.max_bound = tripoint_abs_sm(
+                                   bounds_obj.get_int( "max_x" ),
+                                   bounds_obj.get_int( "max_y" ),
+                                   bounds_obj.get_int( "max_z" ) );
+            bounds.boundary_terrain = ter_str_id( bounds_obj.get_string( "boundary_terrain" ) );
+            bounds.boundary_overmap_terrain = oter_str_id(
+                                                 bounds_obj.get_string( "boundary_overmap_terrain" ) );
+            m.set_dimension_bounds( bounds );
+            overmap_buffer.set_dimension_bounds( bounds );
+        }
 
         load_map(
             tripoint( lev.x + com.x * OMAPX * 2, lev.y + com.y * OMAPY * 2, lev.z ),

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2143,6 +2143,53 @@ void item::craft_data::deserialize( const JsonObject &obj )
     obj.read( "cached_tool_selections", cached_tool_selections );
 }
 
+void item::pocket_dimension_data::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "instance_id", instance_id );
+    jsout.member( "dimension_type", dimension_type );
+    jsout.member( "entry_point", entry_point );
+    jsout.member( "bounds_min", bounds_min );
+    jsout.member( "bounds_max", bounds_max );
+    jsout.member( "is_initialized", is_initialized );
+    jsout.member( "terrain_generated", terrain_generated );
+    jsout.member( "return_dimension", return_dimension );
+    jsout.member( "return_instance_id", return_instance_id );
+    jsout.member( "return_point", return_point );
+    jsout.end_object();
+}
+
+void item::pocket_dimension_data::deserialize( JsonIn &jsin )
+{
+    JsonObject obj = jsin.get_object();
+    obj.allow_omitted_members();
+    obj.read( "instance_id", instance_id );
+    obj.read( "dimension_type", dimension_type );
+    obj.read( "entry_point", entry_point );
+    obj.read( "bounds_min", bounds_min );
+    obj.read( "bounds_max", bounds_max );
+    is_initialized = obj.get_bool( "is_initialized", false );
+    terrain_generated = obj.get_bool( "terrain_generated", false );
+    obj.read( "return_dimension", return_dimension );
+    obj.read( "return_instance_id", return_instance_id );
+    obj.read( "return_point", return_point );
+}
+
+// Full equivalence. Consider only checking identifying data.
+bool item::pocket_dimension_data::operator==( const pocket_dimension_data &rhs ) const
+{
+    return instance_id == rhs.instance_id &&
+           dimension_type == rhs.dimension_type &&
+           entry_point == rhs.entry_point &&
+           bounds_min == rhs.bounds_min &&
+           bounds_max == rhs.bounds_max &&
+           is_initialized == rhs.is_initialized &&
+           terrain_generated == rhs.terrain_generated &&
+           return_dimension == rhs.return_dimension &&
+           return_instance_id == rhs.return_instance_id &&
+           return_point == rhs.return_point;
+}
+
 // Template parameter because item::craft_data is private and I don't want to make it public.
 template<typename T>
 static void load_legacy_craft_data( io::JsonObjectInputArchive &archive, T &value )
@@ -2390,6 +2437,8 @@ void item::io( Archive &archive )
 
     static const cata::value_ptr<relic> null_relic_ptr = nullptr;
     archive.io( "relic_data", relic_data, null_relic_ptr );
+
+    archive.io( "pocket_dim", pocket_dim, std::optional<pocket_dimension_data>() );
 
     archive.io( "drop_token", drop_token, decltype( drop_token )() );
 

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -160,7 +160,7 @@ void scent_map::update( const tripoint &center, map &m )
 
     //the block and reduce scent properties are folded into a single scent_transfer value here
     //block=0 reduce=1 normal=5
-    scent_array<char> scent_transfer;
+    scent_array<char> scent_transfer{};
 
     std::array < std::array < int, 3 + SCENT_RADIUS * 2 >, 1 + SCENT_RADIUS * 2 > new_scent;
     std::array < std::array < int, 3 + SCENT_RADIUS * 2 >, 1 + SCENT_RADIUS * 2 > sum_3_scent_y;

--- a/src/secondary_world.cpp
+++ b/src/secondary_world.cpp
@@ -1,0 +1,170 @@
+#include "secondary_world.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "debug.h"
+#include "game.h"
+#include "map.h"
+#include "mapbuffer.h"
+#include "overmap.h"
+#include "overmapbuffer.h"
+#include "submap.h"
+
+secondary_world::secondary_world( const world_type_id &type, const std::string &instance_id )
+    : world_type_( type )
+    , instance_id_( instance_id )
+{
+}
+
+secondary_world::~secondary_world()
+{
+    if( loaded_ ) {
+        unload();
+    }
+}
+
+void secondary_world::capture_from_primary(
+    const std::optional<dimension_bounds> &bounds,
+    const tripoint_abs_sm &simulation_center )
+{
+    // Transfer submaps from MAPBUFFER
+    for( auto it = MAPBUFFER.begin(); it != MAPBUFFER.end(); ++it ) {
+        submaps_[it->first] = std::move( it->second );
+    }
+
+    // Overmaps are already saved to disk by the caller (travel_to_dimension)
+    // with the correct dimension prefix BEFORE the world type switch.
+    // Do NOT call overmap_buffer.save() here — the prefix has already changed
+    // to the destination dimension, so saving here would corrupt the destination's
+    // overmap files with this dimension's (mostly empty) overmap data.
+
+    bounds_ = bounds;
+    simulation_center_ = simulation_center;
+    loaded_ = true;
+
+    // Clear the primary buffers after transfer
+    // MAPBUFFER submaps were moved, so just clear the container
+    MAPBUFFER.clear();
+    overmap_buffer.clear();
+}
+
+void secondary_world::restore_to_primary()
+{
+    if( !loaded_ ) {
+        debugmsg( "Attempted to restore from unloaded secondary_world" );
+        return;
+    }
+
+    // Save secondary state before restoring
+    save_state();
+
+    // Transfer submaps back to MAPBUFFER
+    for( auto &pair : submaps_ ) {
+        MAPBUFFER.add_submap( pair.first, pair.second );
+    }
+    submaps_.clear();
+
+    // Overmaps will be loaded from disk by the normal load path
+    // since we saved them above
+
+    loaded_ = false;
+}
+
+void secondary_world::save_state()
+{
+    if( !loaded_ ) {
+        return;
+    }
+
+    // Save is handled by the normal save path which writes to dimension-prefixed files
+    // The submaps and overmaps in this secondary world are already associated with
+    // the correct dimension through the game's dimension prefix system
+}
+
+void secondary_world::simulate_tick( const std::string &level, time_duration delta )
+{
+    if( !loaded_ ) {
+        return;
+    }
+
+    // "none" level means keep loaded but frozen - no simulation
+    if( level == "none" || level == "off" ) {
+        return;
+    }
+
+    if( level == "minimal" ) {
+        simulate_minimal( delta );
+    } else if( level == "moderate" ) {
+        simulate_minimal( delta );
+        simulate_moderate( delta );
+    } else if( level == "full" ) {
+        simulate_minimal( delta );
+        simulate_moderate( delta );
+        simulate_full( delta );
+    }
+}
+
+void secondary_world::unload()
+{
+    if( !loaded_ ) {
+        return;
+    }
+
+    // Save before unloading
+    save_state();
+
+    submaps_.clear();
+    overmaps_.clear();
+    bounds_.reset();
+    loaded_ = false;
+}
+
+bool secondary_world::is_in_bounds( const tripoint &sm_pos ) const
+{
+    if( !bounds_ ) {
+        // No bounds means everything is in bounds (infinite dimension)
+        return true;
+    }
+    return bounds_->contains( tripoint_abs_sm( sm_pos ) );
+}
+
+void secondary_world::simulate_minimal( time_duration /*delta*/ )
+{
+    // Minimal simulation: process fields (fire, gas)
+    // This would iterate over loaded submaps and process their fields
+    // For now, this is a stub - full implementation would require
+    // creating a temporary map context or refactoring field processing
+    // to work without the global map object
+
+    // TODO: Implement field processing for secondary worlds
+    // This requires either:
+    // 1. Creating a lightweight field processor that works on raw submaps
+    // 2. Temporarily swapping buffers, creating a map, processing, then swapping back
+    // Option 2 is simpler but has more overhead
+}
+
+void secondary_world::simulate_moderate( time_duration /*delta*/ )
+{
+    // Moderate simulation: vehicle systems (solar charging, battery drain)
+    // Vehicles are stored in submaps, so we'd need to iterate and process them
+    // Similar challenges to minimal simulation
+
+    // TODO: Implement vehicle idle processing for secondary worlds
+    // Vehicle::idle() handles solar charging, fuel consumption, etc.
+    // Would need to call this for each vehicle in loaded submaps
+}
+
+void secondary_world::simulate_full( time_duration /*delta*/ )
+{
+    // Full simulation: everything including monsters, NPCs, combat
+    // This is the most complex and would essentially require running
+    // a parallel game loop
+
+    // TODO: Implement full simulation for secondary worlds
+    // This would include:
+    // - Monster AI and movement
+    // - NPC needs and activities
+    // - Combat resolution
+    // For now, this level of simulation is not implemented
+}

--- a/src/secondary_world.h
+++ b/src/secondary_world.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "calendar.h"
+#include "coordinates.h"
+#include "dimension_bounds.h"
+#include "type_id.h"
+
+class submap;
+class overmap;
+
+/**
+ * Holds the state of a secondary dimension that is kept loaded in memory
+ * for fast travel and optional background simulation.
+ *
+ * This class maintains separate map and overmap buffers from the primary world,
+ * allowing the game to keep a pocket dimension loaded while the player is in
+ * another dimension.
+ */
+class secondary_world
+{
+    public:
+        /**
+         * Construct a secondary world for the given world type and instance.
+         * @param type The world type of this dimension
+         * @param instance_id The unique instance ID (for pocket dimensions)
+         */
+        explicit secondary_world( const world_type_id &type, const std::string &instance_id );
+
+        // Non-copyable, movable
+        secondary_world( const secondary_world & ) = delete;
+        secondary_world &operator=( const secondary_world & ) = delete;
+        secondary_world( secondary_world && ) = default;
+        secondary_world &operator=( secondary_world && ) = default;
+
+        ~secondary_world();
+
+        /**
+         * Transfer buffers from the primary world into this secondary world.
+         * Called when leaving a dimension that should be kept loaded.
+         * @param bounds The dimension bounds (for bounded pocket dimensions)
+         * @param simulation_center The last player position for simulation purposes
+         */
+        void capture_from_primary( const std::optional<dimension_bounds> &bounds,
+                                   const tripoint_abs_sm &simulation_center );
+
+        /**
+         * Restore buffers back to the primary world.
+         * Called when returning to this kept-loaded dimension.
+         * After calling this, the secondary_world is in an invalid state
+         * and should be destroyed.
+         */
+        void restore_to_primary();
+
+        /**
+         * Save the secondary world state to disk.
+         */
+        void save_state();
+
+        /**
+         * Simulate one tick of time passing in this dimension.
+         * What gets simulated depends on the simulation level setting.
+         * @param level The simulation level ("minimal", "moderate", "full")
+         * @param delta Time duration to simulate (defaults to 1 turn, for future batch processing)
+         */
+        void simulate_tick( const std::string &level, time_duration delta = 1_turns );
+
+        /**
+         * Free all memory held by this secondary world.
+         * After calling this, is_loaded() will return false.
+         */
+        void unload();
+
+        bool is_loaded() const {
+            return loaded_;
+        }
+
+        const world_type_id &get_world_type() const {
+            return world_type_;
+        }
+
+        const std::string &get_instance_id() const {
+            return instance_id_;
+        }
+
+    private:
+        world_type_id world_type_;
+        std::string instance_id_;
+        bool loaded_ = false;
+
+        // Separate buffers for this dimension
+        // Using raw map instead of unique_ptr to mapbuffer to avoid circular dependencies
+        std::map<tripoint, std::unique_ptr<submap>> submaps_;
+        std::unordered_map<point_abs_om, std::unique_ptr<overmap>> overmaps_;
+
+        // Cached bounds for simulation
+        std::optional<dimension_bounds> bounds_;
+
+        // Simulation state
+        tripoint_abs_sm simulation_center_;
+
+        // Simulation methods for each level
+        void simulate_minimal( time_duration delta );
+        void simulate_moderate( time_duration delta );
+        void simulate_full( time_duration delta );
+
+        // Helper to check if a position is within bounds
+        bool is_in_bounds( const tripoint &sm_pos ) const;
+};

--- a/src/type_id.h
+++ b/src/type_id.h
@@ -205,6 +205,9 @@ using vproto_id = string_id<vehicle_prototype>;
 struct weather_type;
 using weather_type_id = string_id<weather_type>;
 
+struct world_type;
+using world_type_id = string_id<world_type>;
+
 class zone_type;
 using zone_type_id = string_id<zone_type>;
 

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -1180,12 +1180,13 @@ auto weather_manager::get_temperature( const tripoint &location ) const -> units
     // local modifier
     int temp_mod = 0;
 
-    if( !g->new_game ) {
+    if( !g->new_game && !g->swapping_dimensions ) {
         temp_mod += get_heat_radiation( location, false );
         temp_mod += get_convection_temperature( location );
     }
 
-    const int added_f = g->new_game ? 0 : g->m.get_temperature( location ) + temp_mod;
+    const int added_f = ( g->new_game || g->swapping_dimensions ) ? 0 :
+                         g->m.get_temperature( location ) + temp_mod;
 
     // Calculate base temperature with underground influence
     units::temperature base_temp;

--- a/src/world_type.cpp
+++ b/src/world_type.cpp
@@ -1,0 +1,95 @@
+#include "world_type.h"
+
+#include "generic_factory.h"
+#include "json.h"
+#include "mapdata.h"
+
+namespace
+{
+generic_factory<world_type> world_type_factory( "world_type" );
+const world_type_id default_world_type_id( "default" );
+} // namespace
+
+template<>
+const world_type &world_type_id::obj() const
+{
+    return world_type_factory.obj( *this );
+}
+
+template<>
+bool string_id<world_type>::is_valid() const
+{
+    return world_type_factory.is_valid( *this );
+}
+
+void world_type::load( const JsonObject &jo, const std::string & )
+{
+    mandatory( jo, was_loaded, "name", name );
+
+    optional( jo, was_loaded, "description", description );
+    optional( jo, was_loaded, "region_settings", region_settings_id, "default" );
+    optional( jo, was_loaded, "generate_overmap", generate_overmap, true );
+    optional( jo, was_loaded, "infinite_bounds", infinite_bounds, true );
+
+    if( jo.has_member( "boundary_terrain" ) ) {
+        boundary_terrain = ter_str_id( jo.get_string( "boundary_terrain" ) );
+    }
+
+    optional( jo, was_loaded, "simulate_when_inactive", simulate_when_inactive, false );
+    optional( jo, was_loaded, "save_prefix", save_prefix, "" );
+    optional( jo, was_loaded, "allow_npc_travel", allow_npc_travel, false );
+    optional( jo, was_loaded, "allow_vehicle_travel", allow_vehicle_travel, false );
+
+    if( jo.has_member( "parent_dimension" ) ) {
+        parent_dimension = world_type_id( jo.get_string( "parent_dimension" ) );
+    }
+}
+
+void world_type::check() const
+{
+    if( boundary_terrain && !boundary_terrain->is_valid() ) {
+        debugmsg( "World type \"%s\" has invalid boundary_terrain \"%s\"",
+                  id.str(), boundary_terrain->str() );
+    }
+
+    if( parent_dimension && !parent_dimension->is_valid() ) {
+        debugmsg( "World type \"%s\" has invalid parent_dimension \"%s\"",
+                  id.str(), parent_dimension->str() );
+    }
+
+    // Bounded dimensions should have boundary terrain defined
+    if( !infinite_bounds && !boundary_terrain ) {
+        debugmsg( "World type \"%s\" has infinite_bounds=false but no boundary_terrain defined",
+                  id.str() );
+    }
+}
+
+void world_types::reset()
+{
+    world_type_factory.reset();
+}
+
+void world_types::finalize_all()
+{
+    world_type_factory.finalize();
+}
+
+const std::vector<world_type> &world_types::get_all()
+{
+    return world_type_factory.get_all();
+}
+
+void world_types::check_consistency()
+{
+    world_type_factory.check();
+}
+
+void world_types::load( const JsonObject &jo, const std::string &src )
+{
+    world_type_factory.load( jo, src );
+}
+
+const world_type_id &world_types::get_default()
+{
+    return default_world_type_id;
+}

--- a/src/world_type.h
+++ b/src/world_type.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "translations.h"
+#include "type_id.h"
+
+template<typename T> class generic_factory;
+class JsonObject;
+
+/**
+ * Defines a dimension/world type for multi-dimension support.
+ *
+ * World types specify how dimensions are generated, bounded, saved, and simulated.
+ * They replace hardcoded dimension strings with JSON-loadable types for modding support.
+ */
+struct world_type {
+    private:
+        friend class generic_factory<world_type>;
+        bool was_loaded = false;
+
+    public:
+        world_type_id id;
+
+        // Display information
+        translation name;
+        translation description;
+
+        // Generation settings
+        std::string region_settings_id = "default";  // Links to regional_settings
+        bool generate_overmap = true;                // False for bounded pocket dims
+        bool infinite_bounds = true;                 // False for pocket dimensions
+
+        // Boundaries (for bounded dimensions)
+        std::optional<ter_str_id> boundary_terrain;  // Visual tile for out-of-bounds
+        // Note: bash message comes from the terrain definition itself
+
+        // Simulation
+        bool simulate_when_inactive = false;  // For keep-world-loaded feature
+
+        // Save structure
+        std::string save_prefix;  // Folder/file naming prefix (empty for default dimension)
+
+        // Transport (future)
+        bool allow_npc_travel = false;
+        bool allow_vehicle_travel = false;
+
+        // Hierarchy
+        std::optional<world_type_id> parent_dimension;
+
+        void load( const JsonObject &jo, const std::string &src );
+        void check() const;
+};
+
+namespace world_types
+{
+/** Get all currently loaded world types */
+const std::vector<world_type> &get_all();
+/** Finalize all loaded world types */
+void finalize_all();
+/** Clear all loaded world types (invalidating any pointers) */
+void reset();
+/** Load world type from JSON definition */
+void load( const JsonObject &jo, const std::string &src );
+/** Checks all loaded from JSON are valid */
+void check_consistency();
+
+/** Get the default world type (base reality) */
+const world_type_id &get_default();
+} // namespace world_types


### PR DESCRIPTION
## Purpose of change (The Why)

Ports features of https://github.com/cataclysmbn/Cataclysm-BN/pull/8016 to this PR
More scaffolding in the form of world_type
Show world name in bottom right of Overmap

## Describe the solution (The How)

*suffering*

## Describe alternatives you've considered

*more suffering*

## Testing

I tested the pocket watch items and the dimension key item.
They work under sane conditions, but there's some unsolved issues.
Mostly regarding where you end up coordinate-wise after leaving a pocket dimension when things aren't sterile.
Also, pocket dimension items are perma-locked to the dimension you first use them in instead of just until you return. Should be an easy fix, but not right now.

## Additional context

I am exhausted having done this twice.
I'll be happy to work on something new, even if for this PR.
This was a lot of error whack-a-mole.